### PR TITLE
Combine Worker & Client Packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Virtual environments
+.venv/
+env/
+venv/
+
+# Git files
+.git/
+.gitignore
+
+# Logs & temporary files
+*.log
+*.tmp
+
+# Docker-related
+Dockerfile
+.dockerignore
+
+# Local configs and credentials
+.env
+*.pem
+*.key
+
+# IDE/editor folders
+.vscode/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[project]
+name = "sleap-rtc"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "aiortc",
+    "websockets",
+    "requests",
+    "pyzmq",
+    "jsonpickle",
+    "boto3",
+    "sleap",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "ruff",
+]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "D",  # pydocstyle
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/sleap_RTC/.devcontainer/devcontainer.json
+++ b/sleap_RTC/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "SLEAP WebRTC Container",
+	"build": {
+		"context": "..",
+		"dockerfile": "../Dockerfile"
+	},
+	"forwardPorts": [],
+    "runArgs": [
+      "--gpus=all"
+    ],
+	"customizations": {
+		"vscode": {
+		"settings": {
+			"terminal.integrated.defaultProfile.linux": "bash"
+		}
+		}
+	},
+	"postCreateCommand": "echo 'Devcontainer ready for use!'",
+	"remoteUser": "root"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+ 
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"

--- a/sleap_RTC/client/.dockerignore
+++ b/sleap_RTC/client/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Ignore virtual environments
+env/
+venv/
+
+# Ignore version control and logs
+.git/
+*.log
+
+# Ignore Docker build artifacts
+docker/*.tmp
+
+README.md
+.gitignore
+terraform/*

--- a/sleap_RTC/client/Dockerfile
+++ b/sleap_RTC/client/Dockerfile
@@ -1,0 +1,48 @@
+# Base image with SLEAP and GPU support
+# https://hub.docker.com/repository/docker/eberrigan/sleap-cuda/general
+# FROM eberrigan/sleap-cuda:latest
+
+# Use Python base image and install uv
+FROM python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+# opencv requires opengl https://github.com/conda-forge/opencv-feedstock/issues/401
+# Default python3 is 3.8 in ubuntu 20.04 https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Goal: Connect to Remote Signaling Server w/ aiortc and websockets
+  
+# Install websocket dependencies onto image @ build time (asyncio is included in python3.8)
+# put into requirement.txt later
+
+# Install zip function
+RUN apt-get update && apt-get install -y zip unzip 
+
+# Copy the sleap_webRTC directory into the image's root dir
+COPY ../../pyproject.toml /app/
+COPY client.py /app/
+COPY rtc_gui_client.py /app/
+
+# Install dependencies 
+RUN uv sync 
+
+# Create shared file directory inside container 
+RUN mkdir -p /app/shared_data && chmod 777 /app/shared_data
+
+# Port exposed by the container, NOT computer (localhost), 8080 = websocket server, 3478 = TURN server
+EXPOSE 8080 8001 5000 3478/udp 3478/tcp 9001/tcp 9000/tcp
+
+# Signaling server -> worker -> client in sequenece
+# Worker makes req to signaling server, signaling server sends offer to client and accepts offer
+# Connection is established between client and worker
+# ENTRYPOINT ["sh", "-c", "python3 /app/worker.py"]
+
+
+
+

--- a/sleap_RTC/client/client.py
+++ b/sleap_RTC/client/client.py
@@ -1,0 +1,583 @@
+import asyncio
+import argparse
+import websockets
+import json
+import logging
+import os
+
+from aiortc import RTCPeerConnection, RTCSessionDescription, RTCDataChannel
+from functools import partial
+from qtpy import QtCore
+from sleap.gui.widgets.monitor import LossViewer
+from sleap.gui.widgets.imagedir import QtImageDirectoryWidget
+from sleap.gui.learning.configs import ConfigFileInfo
+from sleap.nn.config.training_job import TrainingJobConfig
+from websockets.client import ClientConnection
+
+# Setup logging.
+logging.basicConfig(level=logging.INFO)
+
+# Global constants.
+CHUNK_SIZE = 64 * 1024
+MAX_RECONNECT_ATTEMPTS = 5
+RETRY_DELAY = 5  # seconds
+
+# Global variables.
+received_files = {}
+target_worker = None
+reconnecting = False
+reconnect_attempts = 0
+output_dir = ""
+win = None
+
+
+async def clean_exit(pc: RTCPeerConnection, websocket: ClientConnection):
+    """Cleans up the client connection and closes the peer connection and websocket.
+    
+    Args:
+        pc: RTCPeerConnection object
+        websocket: ClientConnection object
+    Returns:
+        None
+    """
+
+    logging.info("Closing WebRTC connection...")
+    await pc.close()
+
+    logging.info("Closing websocket connection...")
+    await websocket.close()
+
+    logging.info("Client shutdown complete. Exiting...")
+
+
+async def reconnect(pc: RTCPeerConnection, websocket: ClientConnection):
+    """Attempts to reconnect the client to the worker peer by creating a new offer with ICE restart flag.
+
+    Args:
+        pc: RTCPeerConnection object
+        websocket: ClientConnection object
+    Returns:
+        bool: True if reconnection was successful, False otherwise
+    """
+
+    # Attempt to reconnect.
+    global reconnect_attempts
+    while reconnect_attempts < MAX_RECONNECT_ATTEMPTS:
+        try:
+            reconnect_attempts += 1
+            logging.info(f"Reconnection attempt {reconnect_attempts}/{MAX_RECONNECT_ATTEMPTS}...")
+
+            # Create new offer with ICE restart flag.
+            logging.info("Creating new offer with manual ICE restart...")
+            await pc.setLocalDescription(await pc.createOffer())
+
+            # Send new offer to the worker via signaling.
+            logging.info(f"Sending new offer to worker: {target_worker}")
+            await websocket.send(json.dumps({
+                'type': pc.localDescription.type,
+                'target': target_worker,
+                'sdp': pc.localDescription.sdp
+            }))
+
+            # Wait for connection to complete.
+            for _ in range(30):
+                await asyncio.sleep(1)
+                if pc.iceConnectionState in ["connected", "completed"]:
+                    logging.info("Reconnection successful.")
+
+                    # Clear received files on reconnection.
+                    logging.info("Clearing received files on reconnection...")
+                    received_files.clear()  
+
+                    return True
+
+            logging.warning("Reconnection timed out. Retrying...")
+    
+        except Exception as e:
+            logging.error(f"Reconnection failed with error: {e}")
+
+        await asyncio.sleep(RETRY_DELAY)
+    
+    # Maximum reconnection attempts reached.
+    logging.error("Maximum reconnection attempts reached. Exiting...")
+    await clean_exit(pc, websocket)
+    return False
+
+
+async def handle_connection(pc: RTCPeerConnection, websocket: ClientConnection):
+    """Handles receiving SDP answer from Worker and ICE candidates from Worker.
+
+    Args:
+        pc: RTCPeerConnection object
+        websocket: websocket connection object 
+    Returns:
+		None
+    Raises:
+		JSONDecodeError: Invalid JSON received
+		Exception: An error occurred while handling the message
+    """
+
+    # Handle incoming websocket messages.
+    try:
+        async for message in websocket:
+            if type(message) == int:
+                logging.info(f"Received int message: {message}")
+
+            data = json.loads(message)
+
+            # Receive answer SDP from worker and set it as this peer's remote description.
+            if data.get('type') == 'answer':
+                logging.info(f"Received answer from worker: {data}")
+
+                await pc.setRemoteDescription(RTCSessionDescription(sdp=data.get('sdp'), type=data.get('type')))
+
+            # Handle "trickle ICE" for non-local ICE candidates.
+            elif data.get('type') == 'candidate':
+                logging.info("Received ICE candidate")
+                candidate = data.get('candidate')
+                await pc.addIceCandidate(candidate)
+
+            # NOT initiator, received quit request from worker.
+            elif data.get('type') == 'quit': 
+                logging.info("Worker has quit. Closing connection...")
+                await clean_exit(pc, websocket)
+                break
+
+            # Unhandled message types.
+            else:
+                logging.debug(f"Unhandled message: {data}")
+                logging.debug("exiting...")
+                break
+    
+    except json.JSONDecodeError:
+        logging.DEBUG("Invalid JSON received")
+
+    except Exception as e:
+        logging.DEBUG(f"Error handling message: {e}")
+
+
+async def run_client(
+        peer_id: str, 
+        DNS: str, 
+        port_number: str, 
+        file_path: str = None, 
+        CLI: bool = True,
+        output_dir: str = "",
+        config_filename: TrainingJobConfig = None, 
+        cfg_head_name: str = None,
+        loss_viewer: LossViewer = None # MUST INITIALIZE LOSS VIEWER FOR WINDOW
+    ):
+    """Sends initial SDP offer to worker peer and establishes both connection & datachannel to be used by both parties.
+	
+    Args:
+		peer_id: Unique str identifier for client
+        DNS: DNS address of the signaling server
+        port_number: Port number of the signaling server
+        file_path: Path to a file to be sent to worker peer (usually zip file)
+        CLI: Boolean indicating if the client is running in CLI mode
+        output_dir: Directory to save files received from worker peer
+    Returns:
+		None
+    """
+
+    # Initialize global variables
+    global reconnect_attempts
+    global win
+    output_dir = output_dir
+
+    # Initalize peer connection and data channel.
+    reconnect_attempts = 0
+    pc = RTCPeerConnection()
+    channel = pc.createDataChannel("my-data-channel")
+    logging.info("channel(%s) %s" % (channel.label, "created by local party."))
+
+    # Initialize LossViewer RTC data channel event handlers .
+    logging.info("Setting up RTC data channel for LossViewer...")
+    loss_viewer.set_rtc_channel(channel)
+    win = loss_viewer
+
+    async def keep_ice_alive(channel: RTCDataChannel):
+        """Sends periodic keep-alive messages to the worker peer to maintain the connection.
+
+        Args:
+            channel: RTCDataChannel object
+        Returns:
+            None
+        """
+
+        while True:
+            await asyncio.sleep(15)
+            if channel.readyState == "open":
+                channel.send(b"KEEP_ALIVE")
+
+
+    async def send_client_messages():
+        """Takes input/file from client and sends it to worker peer via datachannel.
+        Args:
+            None
+        Returns:
+            None
+        """
+
+        message = input("Enter message to send (type 'file' to prompt file or type 'quit' to exit): ")
+        data = None
+
+        if message.lower() == "quit":
+            logging.info("Quitting...")
+            await pc.close()
+            return 
+        
+        if channel.readyState != "open":
+            logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+            return 
+        
+        if message.lower() == "file":
+            logging.info("Prompting file...")
+            file_path = input("Enter file path: (or type 'quit' to exit): ")
+            if not file_path:
+                logging.info("No file path entered.")
+                return
+            if file_path.lower() == "quit":
+                logging.info("Quitting...")
+                await pc.close()
+                return
+            if not os.path.exists(file_path):
+                logging.info("File does not exist.")
+                return
+            else: 
+                logging.info(f"Sending {file_path} to worker...")
+                file_name = os.path.basename(file_path)
+                file_size = os.path.getsize(file_path)
+                
+                # Send metadata first
+                channel.send(f"FILE_META::{file_name}:{file_size}")  
+
+                # Send file in chunks (32 KB)
+                with open(file_path, "rb") as file:
+                    logging.info(f"File opened: {file_path}")
+                    while chunk := file.read(CHUNK_SIZE):
+                        while channel.bufferedAmount is not None and channel.bufferedAmount > 16 * 1024 * 1024: # Wait if buffer >16MB 
+                            await asyncio.sleep(0.1)
+
+                        channel.send(chunk)
+
+                channel.send("END_OF_FILE")
+                logging.info(f"File sent to worker.")
+                    
+                # Flag data to True to prevent reg msg from being sent
+                data = True
+
+        if not data: 
+          channel.send(message)
+          logging.info(f"Message sent to worker.")
+        
+        else:
+            return
+
+
+    async def send_client_file():
+        """Handles direct, one-way file transfer from client to be sent to worker peer.
+
+        Args:
+			None
+		Returns:
+			None
+        """
+        
+        # Check channel state before sending file.
+        if channel.readyState != "open":
+            logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+            return 
+
+        # Send file to worker.
+        logging.info(f"Given file path {file_path}")
+        if not file_path:
+            logging.info("No file path entered.")
+            return
+        if not os.path.exists(file_path):
+            logging.info("File does not exist.")
+            return
+        else: 
+            logging.info(f"Sending {file_path} to worker...")
+
+            # Send output directory.
+            channel.send(f"OUTPUT_DIR::{output_dir}")
+
+            # Obtain metadata.
+            file_name = os.path.basename(file_path)
+            file_size = os.path.getsize(file_path)
+            
+            # Send metadata next.
+            channel.send(f"FILE_META::{file_name}:{file_size}")  
+
+            # Send file in chunks (32 KB).
+            with open(file_path, "rb") as file:
+                logging.info(f"File opened: {file_path}")
+                while chunk := file.read(CHUNK_SIZE):
+                    while channel.bufferedAmount is not None and channel.bufferedAmount > 16 * 1024 * 1024: # Wait if buffer >16MB 
+                        await asyncio.sleep(0.1)
+
+                    channel.send(chunk)
+
+            channel.send("END_OF_FILE")
+            logging.info(f"File sent to worker.")
+            
+        return
+
+    @channel.on("open")
+    async def on_channel_open():
+        """Event handler function for when the datachannel is open.
+
+        Args:
+			None
+        Returns:
+			None
+        """
+
+        # Initiate keep-alive task.
+        asyncio.create_task(keep_ice_alive(channel))
+        logging.info(f"{channel.label} is open")
+
+        # Setup monitor window for progress reports.
+        # zmq_ports = dict()
+        # zmq_ports["controller_port"] = 9000
+        # zmq_ports["publish_port"] = 9001
+
+        # Prompt for messages or file upload.
+        if CLI:
+            await send_client_messages()
+        else:
+            await send_client_file()
+    
+
+    @channel.on("message")
+    async def on_message(message):
+        """Event handler function for when a message is received on the datachannel from Worker.
+
+        Args:
+            message: The received message, either as a string or bytes.
+        Returns:
+            None
+        """
+
+        # Log the received message.
+        logging.info(f"Client received: {message}")
+        global received_files
+        global output_dir
+        global win
+        
+        # Handle string and bytes messages differently.
+        if isinstance(message, str):
+            if message == b"KEEP_ALIVE":
+                logging.info("Keep alive message received.")
+                return
+            
+            if message == "END_OF_FILE":
+                # File transfer complete, save to disk.
+                file_name, file_data = list(received_files.items())[0]
+
+                try: 
+                    os.makedirs(output_dir, exist_ok=True)
+                    file_path = os.path.join(output_dir, file_name)
+
+                    with open(file_path, "wb") as file:
+                        file.write(file_data)
+                    logging.info(f"File saved as: {file_path}") 
+                except PermissionError:
+                    logging.error(f"Permission denied when writing to: {output_dir}")
+                except Exception as e:
+                    logging.error(f"Failed to save file: {e}")
+                
+                received_files.clear()
+
+                # Update monitor window with file transfer and training completion.
+                win.close()
+
+                if CLI:
+                    # Prompt for next message
+                    logging.info("File transfer complete. Enter next message:")
+                    await send_client_messages()
+                else:
+                    await clean_exit(pc, websocket)
+
+            elif "PROGRESS_REPORT::" in message:
+                # Progress report received from worker.
+                logging.info(message)
+                _, progress = message.split("PROGRESS_REPORT::", 1)
+                
+                # Update LossViewer window with received progress report.
+                if win:
+                    QtCore.QTimer.singleShot(0, partial(win._check_messages, rtc_msg=progress))
+                    # win._check_messages(
+                    #     # Progress should be result from jsonpickle.decode(msg_str)
+                    #     rtc_msg=progress 
+                    # )
+                else:
+                    logging.info(f"No monitor window available! win is {win}")
+
+                # print("Resetting monitor window.")
+                # plateau_patience = config_info.optimization.early_stopping.plateau_patience
+                # plateau_min_delta = config_info.optimization.early_stopping.plateau_min_delta
+                # win.reset(
+                #     what=str(model_type),
+                #     plateau_patience=plateau_patience,
+                #     plateau_min_delta=plateau_min_delta,
+                # )
+                # win.setWindowTitle(f"Training Model - {str(model_type)}")
+                # win.set_message(f"Preparing to run training...")
+                # if save_viz:
+                #     viz_window = QtImageDirectoryWidget.make_training_vizualizer(
+                #         job.outputs.run_path
+                #     )
+                #     viz_window.move(win.x() + win.width() + 20, win.y())
+                #     win.on_epoch.connect(viz_window.poll)
+
+            elif "FILE_META::" in message: 
+                # Metadata received (file name & size)
+                _, meta = message.split("FILE_META::", 1)
+                file_name, file_size, output_dir = meta.split(":")
+
+                if file_name not in received_files:
+                    received_files[file_name] = bytearray()  # Initialize as bytearray
+                logging.info(f"File name received: {file_name}, of size {file_size}, saving to {output_dir}")
+
+            elif "ZMQ_CTRL::" in message:
+                # ZMQ control message received.
+                _, zmq_ctrl = message.split("ZMQ_CTRL::", 1)
+                
+                if zmq_ctrl == "STOP":
+                    win.reset()
+
+            else:
+                logging.info(f"Worker sent: {message}")
+                
+        elif isinstance(message, bytes):
+            if message == b"KEEP_ALIVE":
+                logging.info("Keep alive message received.")
+                return
+            
+            elif b"PROGRESS_REPORT::" in message:
+                # Progress report received from worker.
+                logging.info(message.decode())
+                _, progress = message.decode().split("PROGRESS_REPORT::", 1)
+                
+                # Update LossViewer window with received progress report.
+                if win:
+                    win._check_messages(
+                        # Progress should be result from jsonpickle.decode(msg_str)
+                        rtc_msg=progress 
+                    )
+                else:
+                    logging.info(f"No monitor window available! win is {win}")
+
+            file_name = list(received_files.keys())[0]
+            if file_name not in received_files:
+              received_files[file_name] = bytearray()
+            received_files[file_name].extend(message)    
+
+
+    # @pc.on("iceconnectionstatechange")
+    async def on_iceconnectionstatechange():
+        """Event handler function for when the ICE connection state changes.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+
+        # Log the current ICE connection state.
+        global reconnecting
+        logging.info(f"ICE connection state is now {pc.iceConnectionState}")
+
+        # Check the ICE connection state and handle reconnection logic.
+        if pc.iceConnectionState in ["connected", "completed"]:
+            reconnect_attempts = 0
+            logging.info("ICE connection established.")
+            logging.info(f"reconnect attempts reset to {reconnect_attempts}")
+
+        elif pc.iceConnectionState in ["failed", "disconnected", "closed"] and not reconnecting:
+            logging.warning(f"ICE connection {pc.iceConnectionState}. Attempting reconnect...")
+            reconnecting = True
+
+            if target_worker is None:
+                logging.info(f"No target worker available for reconnection. target_worker is {target_worker}.")
+                await clean_exit(pc, websocket)
+                return
+            
+            reconnection_success = await reconnect(pc, websocket)
+            reconnecting = False
+            if not reconnection_success:
+                logging.info("Reconnection failed. Closing connection...")
+                await clean_exit(pc, websocket)
+                return
+            
+        
+    # Register the event handler explicitly
+    pc.on("iceconnectionstatechange", on_iceconnectionstatechange)
+    
+
+    # Initate the WebSocket connection to the signaling server.
+    async with websockets.connect(f"{DNS}:{port_number}") as websocket:
+
+        # Register the client with the signaling server.
+        await websocket.send(json.dumps({'type': 'register', 'peer_id': peer_id}))
+        logging.info(f"{peer_id} sent to signaling server for registration!")
+
+        # Query for available workers.
+        await websocket.send(json.dumps({'type': 'query'}))
+        response = await websocket.recv()
+        available_workers = json.loads(response)["peers"]
+        logging.info(f"Available workers: {available_workers}")
+
+        # Select a worker to connect to.
+        target_worker = available_workers[0] if available_workers else None
+        logging.info(f"Selected worker: {target_worker}")
+
+        if not target_worker:
+            logging.info("No workers available")
+            return
+        
+        # Create and send SDP offer to worker peer.
+        await pc.setLocalDescription(await pc.createOffer())
+        await websocket.send(json.dumps({'type': pc.localDescription.type, 'target': target_worker, 'sdp': pc.localDescription.sdp}))
+        logging.info('Offer sent to worker')
+
+        # Handle incoming messages from server (e.g. answer from worker).
+        await handle_connection(pc, websocket)
+
+    # Exit.
+    await pc.close()
+    await websocket.close()
+
+def entrypoint():
+    """Main CLI function to run the client.
+      Args:
+        None
+      Returns:
+        None
+    """
+    parser = argparse.ArgumentParser(description="SLEAP webRTC Client")
+
+    parser.add_argument("--server", type=str, default="ws://ec2-54-153-105-27.us-west-1.compute.amazonaws.com", help="WebSocket server DNS/address, ex. 'ws://ec2-54-158-36-90.compute-1.amazonaws.com'")
+    parser.add_argument("--port", type=int, default=8080, help="WebSocket server port number, ex. '8080'")
+    parser.add_argument("--peer_id", type=str, default="client1", help="Unique identifier for the client")
+
+    args = parser.parse_args()
+
+    DNS = args.server
+    port_number = args.port
+    peer_id = args.peer_id
+
+    try: 
+        asyncio.run(run_client(peer_id, DNS, port_number, file_path=None, CLI=True))
+    except KeyboardInterrupt:
+        logging.info("KeyboardInterrupt: Exiting...")
+    finally:
+        logging.info("exited")
+
+
+if __name__ == "__main__":
+    entrypoint()
+
+    

--- a/sleap_RTC/client/pyproject.toml
+++ b/sleap_RTC/client/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "webrtc-external"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "boto3>=1.35.86",
+    "fastapi>=0.115.6",
+    "python-dotenv>=1.0.0",
+    "python-jose[cryptography]>=3.3.0",
+    "requests>=2.32.3",
+    "uvicorn>=0.34.0",
+    "websockets>=14.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "ruff",
+]

--- a/sleap_RTC/client/rtc_gui_client.py
+++ b/sleap_RTC/client/rtc_gui_client.py
@@ -1,0 +1,762 @@
+import asyncio
+import argparse
+import base64
+import uuid
+import requests
+import websockets
+import json
+import jsonpickle
+import logging
+import os
+import zmq
+
+from aiortc import RTCPeerConnection, RTCSessionDescription, RTCDataChannel
+from functools import partial
+from pathlib import Path
+from sleap.gui.widgets.monitor import LossViewer
+from sleap.gui.learning.configs import ConfigFileInfo
+from sleap.nn.config.training_job import TrainingJobConfig
+from typing import List, Optional, Text, Tuple
+from websockets.client import ClientConnection
+
+# Setup logging.
+logging.basicConfig(level=logging.INFO)
+
+# Global constants.
+CHUNK_SIZE = 64 * 1024
+MAX_RECONNECT_ATTEMPTS = 5
+RETRY_DELAY = 5  # seconds
+
+class RTCGUIClient:
+    def __init__(
+        self, 
+        peer_id: str = f"client-{uuid.uuid4()}",
+        DNS: str = "ws://ec2-54-176-92-10.us-west-1.compute.amazonaws.com",
+        port_number: str = "8080",
+    ):
+        # Initialize RTC peer connection and websocket.
+        self.pc = RTCPeerConnection()
+        self.websocket: ClientConnection = None
+        self.data_channel: RTCDataChannel = None
+        self.pc.on("iceconnectionstatechange", self.on_iceconnectionstatechange)
+
+        # Initialize given parameters.
+        self.peer_id = peer_id
+        self.DNS = DNS
+        self.port_number = port_number
+
+        # Other variables.
+        self.received_files = {}
+        self.target_worker = None
+        self.reconnecting = False
+
+
+    def parse_session_string(self, session_string: str):
+        prefix = "sleap-session:"
+        if not session_string.startswith(prefix):
+            raise ValueError(f"Session string must start with '{prefix}'")
+        
+        encoded = session_string[len(prefix):]
+        try:
+            json_str = base64.urlsafe_b64decode(encoded).decode()
+            data = json.loads(json_str)
+            return {
+                "room_id": data.get("r"),
+                "token": data.get("t"),
+                "peer_id": data.get("p"),
+            }
+        except jsonpickle.UnpicklingError as e:
+            raise ValueError(f"Failed to decode session string: {e}")
+
+
+    def request_anonymous_signin(self) -> str:
+        """Request an anonymous token from Signaling Server."""
+
+        url = "http://ec2-54-176-92-10.us-west-1.compute.amazonaws.com:8001/anonymous-signin"
+        response = requests.post(url)
+
+        if response.status_code == 200:
+            return response.json()['id_token']
+        else:
+            logging.error(f"Failed to get anonymous token: {response.text}")
+            return None
+        
+    
+    async def start_zmq_listener(self, channel: RTCDataChannel, zmq_address: str = "tcp://127.0.0.1:9000"):
+        """Starts a ZMQ ctrl SUB socket to listen for ZMQ commands from the LossViewer.
+        
+        Args:
+            channel: The RTCDataChannel to send progress reports to.
+            zmq_address: Address of the ZMQ socket to connect to.
+        Returns:
+            None
+        """
+        # Use LossViewer's already initialized ZMQ control socket.
+        # Initialize SUB socket.
+        logging.info("Starting new ZMQ listener socket...")
+        context = zmq.Context()
+        socket = context.socket(zmq.SUB)
+
+        logging.info(f"Connecting to ZMQ address: {zmq_address}")
+        socket.connect(zmq_address)
+        socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        loop = asyncio.get_event_loop()
+
+        def recv_msg():
+            """Receives a message from the ZMQ socket in a non-blocking way.
+            
+            Returns:
+                The received message as a JSON object, or None if no message is available.
+            """
+            
+            try:
+                # logging.info("Receiving message from ZMQ...")
+                return socket.recv_string(flags=zmq.NOBLOCK)  # or jsonpickle.decode(msg_str) if needed
+            except zmq.Again:
+                return None
+
+        while True:
+            # Send progress as JSON string with prefix.
+            msg = await loop.run_in_executor(None, recv_msg)
+
+            if msg:
+                try:
+                    logging.info(f"Sending ZMQ command to worker: {msg}")
+                    channel.send(f"ZMQ_CTRL::{msg}")
+                    # logging.info("Progress report sent to client.")
+                except Exception as e:
+                    logging.error(f"Failed to send ZMQ progress: {e}")
+                    
+            # Polling interval.
+            await asyncio.sleep(0.05)
+
+
+    def start_zmq_control(self, zmq_address: str = "tcp://127.0.0.1:9001"): # Publish Port
+        """Starts a ZMQ ctrl PUB socket to forward ZMQ commands to the LossViewer.
+    
+        Args:
+            zmq_address: Address of the ZMQ socket to connect to.
+        Returns:
+            None
+        """
+        # Use LossViewer's already initialized ZMQ control socket.
+        # Initialize PUB socket.
+        logging.info("Starting new ZMQ control socket...")
+        context = zmq.Context()
+        socket = context.socket(zmq.PUB)
+
+        logging.info(f"Connecting to ZMQ address: {zmq_address}")
+        socket.connect(zmq_address)
+
+        # Set PUB socket for use in other functions.
+        self.ctrl_socket = socket
+        logging.info("ZMQ control socket initialized.")
+
+
+    async def clean_exit(self):
+        """Cleans up the client connection and closes the peer connection and websocket.
+        
+        Args:
+            pc: RTCPeerConnection object
+            websocket: ClientConnection object
+        Returns:
+            None
+        """
+
+        logging.info("Closing WebRTC connection...")
+        await self.pc.close()
+
+        logging.info("Closing websocket connection...")
+        await self.websocket.close()
+
+        logging.info("Client shutdown complete. Exiting...")
+
+
+    async def reconnect(self):
+        """Attempts to reconnect the client to the worker peer by creating a new offer with ICE restart flag.
+
+        Args:
+            pc: RTCPeerConnection object
+            websocket: ClientConnection object
+        Returns:
+            bool: True if reconnection was successful, False otherwise
+        """
+
+        # Attempt to reconnect.
+        while self.reconnect_attempts < MAX_RECONNECT_ATTEMPTS:
+            try:
+                self.reconnect_attempts += 1
+                logging.info(f"Reconnection attempt {self.reconnect_attempts}/{MAX_RECONNECT_ATTEMPTS}...")
+
+                # Create new offer with ICE restart flag.
+                logging.info("Creating new offer with manual ICE restart...")
+                await self.pc.setLocalDescription(await self.pc.createOffer())
+
+                # Send new offer to the worker via signaling.
+                logging.info(f"Sending new offer to worker: {self.target_worker}")
+                await self.websocket.send(json.dumps({
+                    'type': self.pc.localDescription.type,
+                    'sender': self.peer_id, # should be own peer_id (Zoom username)
+                    'target': self.target_worker, # should be Worker's peer_id
+                    'sdp': self.pc.localDescription.sdp
+                }))
+
+                # Wait for connection to complete.
+                for _ in range(30):
+                    await asyncio.sleep(1)
+                    if self.pc.iceConnectionState in ["connected", "completed"]:
+                        logging.info("Reconnection successful.")
+
+                        # Clear received files on reconnection.
+                        logging.info("Clearing received files on reconnection...")
+                        self.received_files.clear()
+
+                        return True
+
+                logging.warning("Reconnection timed out. Retrying...")
+        
+            except Exception as e:
+                logging.error(f"Reconnection failed with error: {e}")
+
+            await asyncio.sleep(RETRY_DELAY)
+        
+        # Maximum reconnection attempts reached.
+        logging.error("Maximum reconnection attempts reached. Exiting...")
+        await self.clean_exit()
+        return False
+
+
+    async def handle_connection(self):
+        """Handles receiving SDP answer from Worker and ICE candidates from Worker.
+
+        Args:
+            pc: RTCPeerConnection object
+            websocket: websocket connection object 
+        Returns:
+            None
+        Raises:
+            JSONDecodeError: Invalid JSON received
+            Exception: An error occurred while handling the message
+        """
+
+        # Handle incoming websocket messages.
+        try:
+            async for message in self.websocket:
+                if type(message) == int:
+                    logging.info(f"Received int message: {message}")
+
+                data = json.loads(message)
+
+                # Receive answer SDP from worker and set it as this peer's remote description.
+                if data.get('type') == 'answer':
+                    logging.info(f"Received answer from worker: {data}")
+
+                    await self.pc.setRemoteDescription(RTCSessionDescription(sdp=data.get('sdp'), type=data.get('type')))
+
+                # Handle "trickle ICE" for non-local ICE candidates.
+                elif data.get('type') == 'candidate':
+                    logging.info("Received ICE candidate")
+                    candidate = data.get('candidate')
+                    await self.pc.addIceCandidate(candidate)
+
+                # NOT initiator, received quit request from worker.
+                elif data.get('type') == 'quit': 
+                    logging.info("Worker has quit. Closing connection...")
+                    await self.clean_exit()
+                    break
+
+                # Handle the "registered_auth" message from the signaling server.
+                elif data.get('type') == 'registered_auth':
+                    logging.info(f"Client authenticated with server.")
+
+                # Unhandled message types.
+                else:
+                    logging.debug(f"Unhandled message: {data}")
+        
+        except json.JSONDecodeError:
+            logging.DEBUG("Invalid JSON received")
+
+        except Exception as e:
+            logging.DEBUG(f"Error handling message: {e}")
+
+
+    async def keep_ice_alive(self):
+        """Sends periodic keep-alive messages to the worker peer to maintain the connection."""
+
+        while True:
+            await asyncio.sleep(15)
+            if self.data_channel.readyState == "open":
+                self.data_channel.send(b"KEEP_ALIVE")
+
+
+    async def send_client_file(self, file_path: str = None, output_dir: str = ""):
+        """Handles direct, one-way file transfer from client to be sent to worker peer.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+        
+        # Check channel state before sending file.
+        if self.data_channel.readyState != "open":
+            logging.info(f"Data channel not open. Ready state is: {self.data_channel.readyState}")
+            return 
+
+        # Send file to worker.
+        logging.info(f"Given file path {file_path}")
+        if not file_path:
+            logging.info("No file path entered.")
+            return
+        if not Path(file_path).exists():
+            logging.info("File does not exist.")
+            return
+        else: 
+            logging.info(f"Sending {file_path} to worker...")
+
+            # Send output directory (where models will be saved).
+            output_dir = "models"
+            if self.config_info_list:
+                output_dir = self.config_info_list[0].config.outputs.runs_folder
+
+            self.data_channel.send(f"OUTPUT_DIR::{output_dir}")
+
+            # Obtain file metadata.
+            file_name = Path(file_path).name
+            file_size = Path(file_path).stat().st_size
+
+            # Send metadata next.
+            self.data_channel.send(f"FILE_META::{file_name}:{file_size}")
+
+            # Send file in chunks (32 KB).
+            with open(file_path, "rb") as file:
+                logging.info(f"File opened: {file_path}")
+                while chunk := file.read(CHUNK_SIZE):
+                    while self.data_channel.bufferedAmount is not None and self.data_channel.bufferedAmount > 16 * 1024 * 1024: # Wait if buffer >16MB
+                        await asyncio.sleep(0.1)
+
+                    self.data_channel.send(chunk)
+
+            self.data_channel.send("END_OF_FILE")
+            logging.info(f"File sent to worker.")
+
+        # Start ZMQ control socket.
+        self.start_zmq_control()
+        asyncio.create_task(self.start_zmq_listener(self.data_channel))
+        logging.info(f'{self.data_channel.label} ZMQ control socket started')
+            
+        return
+    
+
+    async def on_channel_open(self):
+        """Event handler function for when the datachannel is open.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+
+        # Initiate keep-alive task.
+        asyncio.create_task(self.keep_ice_alive())
+        logging.info(f"{self.data_channel.label} is open")
+
+        # Initiate file upload to send entire training zip file to worker peer.
+        await self.send_client_file(self.file_path, self.output_dir)
+
+
+    async def on_message(self, message):
+        """Event handler function for when a message is received on the datachannel from Worker.
+
+        Args:
+            message: The received message, either as a string or bytes.
+        Returns:
+            None
+        """
+
+        # Log the received message.
+        logging.info(f"Client received: {message}")
+        
+        # Handle string and bytes messages differently.
+        if isinstance(message, str):
+            # if message == b"KEEP_ALIVE":
+            #     logging.info("Keep alive message received.")
+            #     return
+            
+            if message == "END_OF_FILE":
+                # File transfer complete, save to disk.
+                file_name, file_data = list(self.received_files.items())[0]
+
+                try:
+                    os.makedirs(self.output_dir, exist_ok=True)
+                    file_path = Path(self.output_dir).joinpath(file_name)
+    
+                    with open(file_path, "wb") as file:
+                        file.write(file_data)
+                    logging.info(f"File saved as: {file_path}") 
+                except PermissionError:
+                    logging.error(f"Permission denied when writing to: {output_dir}")
+                except Exception as e:
+                    logging.error(f"Failed to save file: {e}")
+                
+                self.received_files.clear()
+
+                # Update monitor window with file transfer and training completion.
+                # Can close LossViewer window NOW since EOF_FILE received.
+                # self.win.close()
+                close_msg = {
+                    "event": "rtc_close_monitor",
+                }
+                self.ctrl_socket.send_string(jsonpickle.encode(close_msg))
+                logging.info("Sent ZMQ close message to LossViewer window.")
+
+            elif "PROGRESS_REPORT::" in message:
+                # Progress report received from worker.
+                logging.info(message)
+                _, progress = message.split("PROGRESS_REPORT::", 1)
+                
+                # Update LossViewer window with received progress report.
+                if self.win:
+                    rtc_progress_msg = {
+                        "event": "rtc_update_monitor",
+                        "rtc_msg": progress
+                    }
+                    self.ctrl_socket.send_string(jsonpickle.encode(rtc_progress_msg))
+
+                    # QtCore.QTimer.singleShot(0, partial(self.win._check_messages, rtc_msg=progress))
+                    # win._check_messages(
+                    #     # Progress should be result from jsonpickle.decode(msg_str)
+                    #     rtc_msg=progress 
+                    # )
+                else:
+                    logging.info(f"No monitor window available! win is {self.win}")
+
+
+                # print("Resetting monitor window.")
+                # plateau_patience = config_info.optimization.early_stopping.plateau_patience
+                # plateau_min_delta = config_info.optimization.early_stopping.plateau_min_delta
+                # win.reset(
+                #     what=str(model_type),
+                #     plateau_patience=plateau_patience,
+                #     plateau_min_delta=plateau_min_delta,
+                # )
+                # win.setWindowTitle(f"Training Model - {str(model_type)}")
+                # win.set_message(f"Preparing to run training...")
+                # if save_viz:
+                #     viz_window = QtImageDirectoryWidget.make_training_vizualizer(
+                #         job.outputs.run_path
+                #     )
+                #     viz_window.move(win.x() + win.width() + 20, win.y())
+                #     win.on_epoch.connect(viz_window.poll)
+
+            elif "FILE_META::" in message: 
+                # Metadata received (file name & size).
+                _, meta = message.split("FILE_META::", 1)
+                file_name, file_size, output_dir = meta.split(":")
+
+                # Initialize received_files with file name as key and empty bytearray as value.
+                if file_name not in self.received_files:
+                    self.received_files[file_name] = bytearray()
+                logging.info(f"File name received: {file_name}, of size {file_size}, saving to {output_dir}")
+
+            elif "ZMQ_CTRL::" in message:
+                # ZMQ control message received.
+                _, zmq_ctrl = message.split("ZMQ_CTRL::", 1)
+                
+                # Handle ZMQ control messages (i.e. STOP or CANCEL).
+
+            elif "TRAIN_JOB_START::" in message:
+                # Training job start message received.
+                _, job_info = message.split("TRAIN_JOB_START::", 1)
+                logging.info(f"Training job started with info: {job_info}")
+
+                # Parse the job info and update the LossViewer window.
+                try:
+                    # Get next config info.
+                    config_info = self.config_info_list.pop(0)
+
+                    # Check for retraining flag.
+                    if config_info.dont_retrain:
+                        if not config_info.has_trained_model:
+                            raise ValueError(
+                                "Config is set to not retrain but no trained model found: "
+                                f"{config_info.path}"
+                            )
+
+                        logging.info(
+                            f"Using already trained model for {config_info.head_name}: "
+                            f"{config_info.path}"
+                        )
+
+                        # Trained job paths not needed because no remote inference (remote training only).
+
+                    # Otherwise, prepare to run training job.
+                    else:
+                        job = config_info.config
+                        model_type = config_info.head_name
+
+                        if self.win:
+                            #
+                            logging.info("Resetting monitor window.")
+                            plateau_patience = job.optimization.early_stopping.plateau_patience
+                            plateau_min_delta = job.optimization.early_stopping.plateau_min_delta
+
+                            # Send reset ZMQ message to LossViewer window.
+                            # In separate thread from LossViewer, must use ZMQ PUB socket to update.
+                            reset_msg = {
+                                "event": "rtc_reset_monitor",
+                                "what": str(model_type),
+                                "plateau_patience": plateau_patience,
+                                "plateau_min_delta": plateau_min_delta,
+                                "window_title": f"Training Model - {str(model_type)}",
+                                "message": "Preparing to run training..."
+                            }
+                            self.ctrl_socket.send_string(jsonpickle.encode(reset_msg))
+
+                            # self.win.reset(
+                            #     what=str(model_type),
+                            #     plateau_patience=plateau_patience,
+                            #     plateau_min_delta=plateau_min_delta,
+                            # )
+                            # self.win.setWindowTitle(f"Training Model - {str(model_type)}")
+                            # self.win.set_message(f"Preparing to run training...")
+                            
+                            # Further updates to the LossViewer window handled by PROGRESS_REPORT messages when training starts remotely.
+
+                        logging.info(f"Start training {str(model_type)} job with config: {job}")
+            
+                except Exception as e:
+                    logging.error(f"Failed to parse training job config: {e}")
+
+            elif "TRAIN_JOB_END::" in message: # ONLY TO SIGNAL TRAINING JOB END, NOT WHOLE TRAINING SESSION END.
+                # Training job end message received.
+                _, job_info = message.split("TRAIN_JOB_END::", 1)
+                logging.info(f"Train job completed: {job_info}, checking for next job...")
+
+                # Update LossViewer window to indicate training completion based on how many training jobs left.
+                if len(self.config_info_list) == 0:
+                    logging.info("No more training jobs to run. Closing LossViewer window.")
+                    # close_msg = {
+                    #     "event": "rtc_close_monitor"
+                    # }
+                    # self.ctrl_socket.send_string(jsonpickle.encode(close_msg))
+                    # await self.clean_exit()
+                else:
+                    logging.info(f"More training jobs to run: {len(self.config_info_list)} remaining.")
+                    # Handle next job with TRAIN_JOB_START message.
+                    
+                    # next_job = self.config_info_list[0]
+                    # if self.win:
+                    #     # Send reset ZMQ message to LossViewer window.
+                    #     reset_msg = {
+                    #         "event": "rtc_reset_monitor",
+                    #         "what": str(next_job.head_name),
+                    #         "plateau_patience": next_job.config.optimization.early_stopping.plateau_patience,
+                    #         "plateau_min_delta": next_job.config.optimization.early_stopping.plateau_min_delta,
+                    #         "window_title": f"Training Model - {str(next_job.head_name)}",
+                    #         "message": "Preparing to run training..."
+                    #     }
+                    #     self.ctrl_socket.send_string(jsonpickle.encode(reset_msg))
+                
+
+            elif "TRAIN_JOB_ERROR::" in message:
+                # Training job error message received.
+                _, error_info = message.split("TRAIN_JOB_ERROR::", 1)
+                logging.error(f"Training job encountered an error: {error_info}")
+                
+        elif isinstance(message, bytes):
+            if message == b"KEEP_ALIVE":
+                logging.info("Keep alive message received.")
+                return
+            
+            elif b"PROGRESS_REPORT::" in message:
+                # Progress report received from worker as bytes.
+                logging.info(message.decode())
+                _, progress = message.decode().split("PROGRESS_REPORT::", 1)
+                
+                # Update LossViewer window with received progress report.
+                if self.win:
+                    rtc_progress_msg = {
+                        "event": "rtc_update_monitor",
+                        "rtc_msg": progress
+                    }
+                    self.ctrl_socket.send_string(jsonpickle.encode(rtc_progress_msg))
+
+                    # QtCore.QTimer.singleShot(0, partial(self.win._check_messages, rtc_msg=progress))
+                    # win._check_messages(
+                    #     # Progress should be result from jsonpickle.decode(msg_str)
+                    #     rtc_msg=progress 
+                    # )
+                else:
+                    logging.info(f"No monitor window available! win is {self.win}")
+
+            file_name = list(self.received_files.keys())[0]
+            if file_name not in self.received_files:
+                self.received_files[file_name] = bytearray()
+            self.received_files[file_name].extend(message)
+
+
+    # @pc.on("iceconnectionstatechange")
+    async def on_iceconnectionstatechange(self):
+        """Event handler function for when the ICE connection state changes.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+
+        # Log the current ICE connection state.
+        logging.info(f"ICE connection state is now {self.pc.iceConnectionState}")
+
+        # Check the ICE connection state and handle reconnection logic.
+        if self.pc.iceConnectionState in ["connected", "completed"]:
+            self.reconnect_attempts = 0
+            logging.info("ICE connection established.")
+            logging.info(f"reconnect attempts reset to {self.reconnect_attempts}")
+
+        elif self.pc.iceConnectionState in ["failed", "disconnected", "closed"] and not self.reconnecting:
+            logging.warning(f"ICE connection {self.pc.iceConnectionState}. Attempting reconnect...")
+            self.reconnecting = True
+
+            if self.target_worker is None:
+                logging.info(f"No target worker available for reconnection. target_worker is {self.target_worker}.")
+                await self.clean_exit()
+                return
+            
+            reconnection_success = await self.reconnect()
+            self.reconnecting = False
+            if not reconnection_success:
+                logging.info("Reconnection failed. Closing connection...")
+                await self.clean_exit()
+                return
+
+
+    async def run_client(
+            self, 
+            file_path: str = None, 
+            output_dir: str = "", 
+            zmq_ports: list = None, 
+            config_info_list: List[ConfigFileInfo] = None,
+            win: LossViewer = None,
+        ):
+        """Sends initial SDP offer to worker peer and establishes both connection & datachannel to be used by both parties.
+        
+        Args:
+            peer_id: Unique str identifier for client
+            DNS: DNS address of the signaling server
+            port_number: Port number of the signaling server
+            file_path: Path to a file to be sent to worker peer (usually zip file)
+            CLI: Boolean indicating if the client is running in CLI mode
+            output_dir: Directory to save files received from worker peer
+        Returns:
+            None
+        """
+
+        # Initialize data channel.
+        channel = self.pc.createDataChannel("my-data-channel")
+        self.data_channel = channel
+        logging.info("channel(%s) %s" % (channel.label, "created by local party."))
+
+        # Set local variable
+        self.win = win
+        self.file_path = file_path
+        self.output_dir = output_dir
+        self.zmq_ports = zmq_ports
+        self.config_info_list = config_info_list
+
+        # Register event handlers for the data channel.
+        channel.on("open", self.on_channel_open)
+        channel.on("message", self.on_message)
+
+        # Initialize LossViewer RTC data channel event handlers.
+        # Doesn't directly interact with window, so doesn't need to be in main thread.
+        logging.info("Setting up RTC data channel for LossViewer...")
+        self.win.set_rtc_channel(channel)   
+        self.reconnect_attempts = 0 
+
+        # Sign-in anonymously with Cognito to get an ID token.
+        id_token = self.request_anonymous_signin()
+
+        if not id_token:
+            logging.error("Failed to get anonymous ID token. Exiting client.")
+            return
+        
+        logging.info(f"Anonymous ID token received: {id_token}")
+
+        # No room creation needed for GUI Client since using Worker credentials.
+        # Only needs its own Cognito ID token and peer ID 
+        # Create the room and get the room ID and token.
+        # room_json = self.request_create_room(id_token)
+        # logging.info(f"Room created with ID: {room_json['room_id']} and token: {room_json['token']}")
+
+        # Initate the WebSocket connection to the signaling server.
+        async with websockets.connect(f"{self.DNS}:{self.port_number}") as websocket:
+
+            # Initate the websocket for the GUI client (so other functions can use). 
+            self.websocket = websocket
+
+            # Prompt for session string.
+            while True:
+                session_string = input("Please enter RTC session string (or type 'exit' to quit): ")
+                if session_string.lower() == "exit":
+                    print("Exiting client.")
+                    return  # <-- This exits the current function (e.g., run_client)
+                try:
+                    session_str_json = self.parse_session_string(session_string)
+                    break  # Exit loop if parsing succeeds
+                except ValueError as e:
+                    print(f"Error: {e}")
+                    print("Please try again or type 'exit' to quit.")
+            
+            # Extract worker credentials from session string.
+            worker_room_id = session_str_json.get("room_id")
+            worker_token = session_str_json.get("token")
+            worker_peer_id = session_str_json.get("peer_id")
+
+            # Register the client with the signaling server.
+            logging.info(f"Registering {self.peer_id} with signaling server...")
+            await self.websocket.send(json.dumps({
+                'type': 'register', 
+                'peer_id': self.peer_id, # should be own peer_id (Zoom username)
+                'room_id': worker_room_id, # should match Worker's room_id (Zoom meeting ID)
+                'token': worker_token, # should match Worker's token (Zoom meeting password)
+                'id_token': id_token, # should be own Cognito ID token
+            }))
+            # await websocket.send(json.dumps({'type': 'register', 'peer_id': self.peer_id}))
+            logging.info(f"{self.peer_id} sent to signaling server for registration!")
+
+            # # Query for available workers.
+            # await websocket.send(json.dumps({'type': 'query'}))
+            # response = await websocket.recv()
+            # available_workers = json.loads(response)["peers"]
+            # logging.info(f"Available workers: {available_workers}")
+
+            # Select a worker to connect to.
+            # target_worker = available_workers[0] if available_workers else None
+
+            # self.peer_id should match Worker's peer_id (Zoom username).
+            self.target_worker = worker_peer_id
+            logging.info(f"Selected worker: {self.target_worker}")
+
+            if not self.target_worker:
+                logging.info("No target worker given. Cannot connect.")
+                return
+            
+            # Create and send SDP offer to worker peer.
+            await self.pc.setLocalDescription(await self.pc.createOffer())
+            await websocket.send(json.dumps({
+                'type': self.pc.localDescription.type, # type: 'offer'
+                'sender': self.peer_id, # should be own peer_id (Zoom username)
+                'target': self.target_worker, # should match Worker's peer_id (Zoom username)
+                'sdp': self.pc.localDescription.sdp
+            }))
+            logging.info('Offer sent to worker')
+
+            # Handle incoming messages from server (e.g. answer from worker).
+            await self.handle_connection()
+
+        # Exit.
+        await self.pc.close()
+        await websocket.close()

--- a/sleap_RTC/worker/.dockerignore
+++ b/sleap_RTC/worker/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Ignore virtual environments
+env/
+venv/
+
+# Ignore version control and logs
+.git/
+*.log
+
+# Ignore Docker build artifacts
+docker/*.tmp
+
+README.md
+.gitignore
+terraform/*

--- a/sleap_RTC/worker/Dockerfile
+++ b/sleap_RTC/worker/Dockerfile
@@ -1,0 +1,50 @@
+# Base image with SLEAP and GPU support
+# https://hub.docker.com/repository/docker/eberrigan/sleap-cuda/general
+# FROM eberrigan/sleap-cuda:latest
+
+# Use a lightweight multi-architecture base image & install uv
+FROM ghcr.io/talmolab/sleap-cuda:linux-amd64-2a8cefd7d0291d2ce07998fa3c54c9d0d618d31b
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+# opencv requires opengl https://github.com/conda-forge/opencv-feedstock/issues/401
+# Default python3 is 3.8 in ubuntu 20.04 https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Goal: Connect to Remote Signaling Server w/ aiortc and websockets
+  
+# Install websocket dependencies onto image @ build time (asyncio is included in python3.8)
+# put into requirement.txt later
+
+# Install zip function
+RUN apt-get update && apt-get install -y zip unzip 
+
+# Copy the sleap_webRTC directory into the image's root dir
+COPY ../../pyproject.toml /app/
+COPY worker.py /app/
+COPY zmq_check.py /app/
+COPY worker_class.py /app/
+COPY run_training.py /app/
+
+# Install dependencies 
+RUN uv sync 
+
+# Create shared file directory inside container 
+RUN mkdir -p /app/shared_data && chmod 777 /app/shared_data
+
+# Port exposed by the container, NOT computer (localhost), 8080 = websocket server, 3478 = TURN server
+EXPOSE 8080 8001 5000 3478/udp 3478/tcp 9001/tcp 9000/tcp
+
+# Signaling server -> worker -> client in sequenece
+# Worker makes req to signaling server, signaling server sends offer to client and accepts offer
+# Connection is established between client and worker
+# ENTRYPOINT ["sh", "-c", "python3 /app/worker.py"]
+
+
+
+

--- a/sleap_RTC/worker/pyproject.toml
+++ b/sleap_RTC/worker/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "webrtc-worker-sleap-container"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "aiortc>=1.0.0",
+    "boto3>=1.26.0",
+    "pyzmq>=25.0.0",
+    "requests>=2.28.0",
+    "websockets>=11.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "black",
+    "ruff",
+]

--- a/sleap_RTC/worker/run_training.py
+++ b/sleap_RTC/worker/run_training.py
@@ -1,0 +1,96 @@
+import asyncio
+import logging
+import subprocess
+import re
+
+from aiortc import RTCPeerConnection, RTCSessionDescription, RTCDataChannel
+from worker_class import RTCWorkerClient
+from pathlib import Path
+
+
+def parse_training_script(training_script_path: str):
+    jobs = []
+    pattern = re.compile(r"^\s*sleap-train\s+([^\s]+)\s+([^\s]+)")
+
+    with open(training_script_path, "r") as f:
+        for line in f:
+            match = pattern.match(line)
+            if match:
+                config, labels = match.groups()
+                jobs.append((config.strip(), labels.strip()))
+    return jobs
+
+
+async def run_all_training_jobs(channel: RTCDataChannel, train_script_path: str, save_dir: str):
+    training_jobs = parse_training_script(train_script_path)
+
+    for config_name, labels_name in training_jobs:
+        job_name = Path(config_name).stem
+
+        # Send RTC msg over channel to indicate job start.
+        logging.info(f"Starting training job: {job_name} with config: {config_name} and labels: {labels_name}")
+        channel.send(f"TRAIN_JOB_START::{job_name}")
+
+        cmd = [
+            "sleap-train",
+            config_name,
+            labels_name,
+            "--zmq",
+            "--controller_port",
+            "9000",
+            "--publish_port",
+            "9001"
+        ]
+        logging.info(f"[RUNNING] {' '.join(cmd)}")
+
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=save_dir
+        )
+
+        assert process.stdout is not None
+
+        async def stream_logs():
+            async for line in process.stdout:
+                decoded_line = line.decode().rstrip()
+                logging.info(decoded_line)
+
+                if channel.readyState == "open":
+                    try:
+                        channel.send(f"TRAIN_LOG:{decoded_line}")
+                    except Exception as e:
+                        logging.error(f"Failed to send log line: {e}")
+
+        await stream_logs()
+        await process.wait()
+
+        if process.returncode == 0:
+            logging.info(f"[DONE] Job {job_name} completed successfully.")
+            if channel.readyState == "open":
+                channel.send(f"TRAIN_END::{job_name}")
+        else:
+            logging.warning(f"[FAILED] Job {job_name} exited with code {process.returncode}.")
+            if channel.readyState == "open":
+                channel.send(f"TRAIN_ERROR::{job_name}::{process.returncode}")
+
+        # try:
+        #     subprocess.run([
+        #         "sleap-train",
+        #         config_name,
+        #         labels_name,
+        #         "--zmq",
+        #         "--controller_port",
+        #         "9000",
+        #         "--publish_port",
+        #         "9001"
+        #     ], check=True)
+        # except subprocess.CalledProcessError as e:
+        #     channel.send(f"TRAIN_JOB_ERROR::{job_name}::{e.stderr}")
+        #     logging.error(f"Training job {job_name} failed with error: {e.stderr}")
+        #     continue
+
+        channel.send(f"TRAIN_JOB_END::{job_name}")
+
+    channel.send("TRAINING_JOBS_DONE")

--- a/sleap_RTC/worker/worker.py
+++ b/sleap_RTC/worker/worker.py
@@ -1,0 +1,610 @@
+import asyncio
+import subprocess
+import stat
+import sys
+import websockets
+import json
+import logging
+import shutil
+import os
+import zmq
+
+from aiortc import RTCPeerConnection, RTCSessionDescription, RTCDataChannel
+from websockets.client import ClientConnection
+from pathlib import Path
+
+# import sleap
+# from sleap.nn.training import main
+
+# Setup logging.
+logging.basicConfig(level=logging.INFO)
+
+# Global constants.
+CHUNK_SIZE = 32 * 1024
+SAVE_DIR = "/app/shared_data"
+
+# Global variables.
+received_files = {}
+output_dir = ""
+ctrl_socket = None
+
+def start_zmq_control(zmq_address: str = "tcp://127.0.0.1:9000"):
+    """Starts a ZMQ control PUB socket to send ZMQ commands to the Trainer.
+   
+    Args:
+        zmq_address: Address of the ZMQ socket to connect to.
+    Returns:
+        None
+    """
+    global ctrl_socket
+
+    # Initialize socket and event loop.
+    logging.info("Starting ZMQ control socket...")
+    context = zmq.Context()
+    socket = context.socket(zmq.PUB)
+
+    logging.info(f"Connecting to ZMQ address: {zmq_address}")
+    socket.bind(zmq_address)
+
+    # set global PUB socket for use in other functions
+    ctrl_socket = socket
+    logging.info("ZMQ control socket initialized.")
+
+
+async def start_progress_listener(channel: RTCDataChannel, zmq_address: str = "tcp://127.0.0.1:9001"):
+    """Starts a listener for ZMQ messages and sends progress updates to the client over the data channel.
+   
+    Args:
+        channel: DataChannel object to send progress updates.
+        zmq_address: Address of the ZMQ socket to connect to.
+    Returns:
+        None
+    """
+
+    # Initialize socket and event loop.
+    logging.info("Starting ZMQ progress listener...")
+    context = zmq.Context()
+    socket = context.socket(zmq.SUB)
+
+    logging.info(f"Connecting to ZMQ address: {zmq_address}")
+    socket.bind(zmq_address) 
+    socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+    loop = asyncio.get_event_loop()
+
+    def recv_msg():
+        """Receives a message from the ZMQ socket in a non-blocking way.
+        
+        Returns:
+            The received message as a JSON object, or None if no message is available.
+        """
+        
+        try:
+            # logging.info("Receiving message from ZMQ...")
+            return socket.recv_string(flags=zmq.NOBLOCK)  # or jsonpickle.decode(msg_str) if needed
+        except zmq.Again:
+            return None
+
+    while True:
+        # Send progress as JSON string with prefix.
+        msg = await loop.run_in_executor(None, recv_msg)
+
+        if msg:
+            try:
+                logging.info(f"Sending progress report to client: {msg}")
+                channel.send(f"PROGRESS_REPORT::{msg}")
+                # logging.info("Progress report sent to client.")
+            except Exception as e:
+                logging.error(f"Failed to send ZMQ progress: {e}")
+                
+        # Polling interval.
+        await asyncio.sleep(0.05)
+
+
+async def zip_results(file_name: str, dir_path: str = SAVE_DIR):
+    """Zips the contents of the shared_data directory and saves it to a zip file.
+
+    Args:
+        file_name: Name of the zip file to be created.
+        dir_path: Path to the directory to be zipped.
+    Returns:
+        None
+    """
+
+    logging.info("Zipping results...")
+    if Path(dir_path):
+        try:
+            shutil.make_archive(file_name.split(".")[0], 'zip', dir_path)
+            logging.info(f"Results zipped to {file_name}")
+        except Exception as e:
+            logging.error(f"Error zipping results: {e}")
+            return
+    else:
+        logging.info(f"{dir_path} does not exist!")
+        return
+
+
+async def unzip_results(file_path: str):
+    """Unzips the contents of the given file path.
+
+    Args:
+        file_path: Path to the zip file to be unzipped.
+    Returns:
+        None
+    """
+
+    logging.info("Unzipping results...")
+    if Path(file_path):
+        try:
+            shutil.unpack_archive(file_path, SAVE_DIR)
+            logging.info(f"Results unzipped from {file_path}")
+        except Exception as e:
+            logging.error(f"Error unzipping results: {e}")
+            return
+    else:
+        logging.info(f"{file_path} does not exist!")
+        return
+    
+
+async def clean_exit(pc: RTCPeerConnection, websocket: ClientConnection):
+    """Handles cleanup and shutdown of the worker.
+
+    Args:
+        pc: RTCPeerConnection object
+        websocket: WebSocket connection object
+    Returns:
+        None    
+    """
+
+    logging.info("Closing WebRTC connection...") 
+    await pc.close()
+
+    logging.info("Closing websocket connection...")
+    await websocket.close()
+
+    logging.info("Client shutdown complete. Exiting...")
+
+
+async def send_worker_messages(pc: RTCPeerConnection, channel: RTCDataChannel):
+    """Handles typed messages from worker to be sent to client peer.
+
+    Args:
+        None
+    Returns:
+        None
+    """
+
+    message = input("Enter message to send (type 'file' to prompt file or type 'quit' to exit): ")
+    data = None
+    
+    if message.lower() == "quit":
+        logging.info("Quitting...")
+        await pc.close()
+        return
+
+    if channel.readyState != "open":
+        logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+        return
+
+    if message.lower() == "file":
+        logging.info("Prompting file...")
+        file_path = input("Enter file path: (or type 'quit' to exit): ")
+        if not file_path:
+            logging.info("No file path entered.")
+            return
+        if file_path.lower() == "quit":
+            logging.info("Quitting...")
+            await pc.close()
+            return
+        if not Path(file_path):
+            logging.info("File does not exist.")
+            return
+        else:
+            logging.info(f"Sending {file_path} to client...")
+            file_name = os.path.basename(file_path)
+            file_size = os.path.getsize(file_path)
+            file_save_dir = output_dir 
+            
+            # Send metadata first
+            channel.send(f"FILE_META::{file_name}:{file_size}:{file_save_dir}")
+            
+            # Send file in chunks (32 KB)
+            with open(file_path, "rb") as file:
+                logging.info(f"File opened: {file_path}")
+                while chunk := file.read(CHUNK_SIZE):
+                    channel.send(chunk)
+            
+            channel.send("END_OF_FILE")
+            logging.info(f"File sent to client.")
+                    
+            # Flag data to True to prevent reg msg from being sent
+            data = True
+
+    if not data:
+        channel.send(message)
+        logging.info(f"Message sent to client.")
+
+
+async def handle_connection(pc: RTCPeerConnection, websocket: ClientConnection):
+    """ Handles incoming messages from the signaling server and processes them accordingly.
+
+    Args:
+        pc: RTCPeerConnection object
+        websocket: WebSocket connection object
+    Returns:
+        None    
+    """
+
+    try:
+        async for message in websocket:
+            data = json.loads(message)
+            
+            # 1. receieve offer SDP from client (forwarded by signaling server)
+            if data.get('type') == "offer":
+                # 1a. set worker peer's remote description to the client's offer based on sdp data
+                logging.info('Received offer SDP')
+
+                await pc.setRemoteDescription(RTCSessionDescription(sdp=data.get('sdp'), type='offer')) 
+                
+                # 1b. generate worker's answer SDP and set it as the local description
+                await pc.setLocalDescription(await pc.createAnswer())
+                
+                # 1c. send worker's answer SDP to client so they can set it as their remote description
+                await websocket.send(json.dumps({'type': pc.localDescription.type, 'target': data.get('target'), 'sdp': pc.localDescription.sdp}))
+
+                # 1d. reset received_files dictionary
+                received_files.clear()
+            
+            # 2. to handle "trickle ICE" for non-local ICE candidates (might be unnecessary)
+            elif data.get('type') == 'candidate':
+                print("Received ICE candidate")
+                candidate = data.get('candidate')
+                await pc.addIceCandidate(candidate)
+
+            elif data.get('type') == 'quit': # NOT initiator, received quit request from worker
+                print("Received quit request from Client. Closing connection...")
+                await clean_exit(pc, websocket)
+                return
+
+            # 3. error handling
+            else:
+                logging.ERROR(f"Unhandled message: {data}")
+                
+    
+    except json.JSONDecodeError:
+        logging.ERROR("Invalid JSON received")
+
+    except Exception as e:
+        logging.ERROR(f"Error handling message: {e}")
+
+        
+async def run_worker(pc, peer_id: str, DNS: str, port_number):
+    """Main function to run the worker. Contains several event handlers for the WebRTC connection and data channel.
+    
+    Args:
+        pc: RTCPeerConnection object
+        peer_id: ID of the worker peer
+        DNS: DNS address of the signaling server
+        port_number: Port number of the signaling server
+    Returns:
+        None
+    """
+
+    async def keep_ice_alive(channel: RTCDataChannel):
+        """Sends periodic keep-alive messages to the client to maintain the connection.
+        
+        Args:
+            channel: DataChannel object
+        Returns:
+            None
+        """
+
+        while True:
+            await asyncio.sleep(15)
+            if channel.readyState == "open":
+                channel.send(b"KEEP_ALIVE")
+
+
+    # Websockets are only necessary here for setting up exchange of SDP & ICE candidates to each other.
+    # Listen for incoming data channel messages on channel established by the client.
+    @pc.on("datachannel")           
+    def on_datachannel(channel: RTCDataChannel):
+        """Handles incoming data channel messages from the client.
+
+        Args:
+            channel: DataChannel object
+        Returns: 
+            None
+        """
+
+        # Listen for incoming messages on the channel.
+        logging.info("channel(%s) %s" % (channel.label, "created by remote party & received."))
+    
+        async def send_worker_file(file_path: str):
+            """Handles direct, one-way file transfer from client to be sent to client peer.
+        
+            Args:
+                file_path: Path to the file to be sent.
+            Returns:
+                None
+            """
+            
+            if channel.readyState != "open":
+                logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+                return 
+
+            logging.info(f"Given file path {file_path}")
+            if not file_path:
+                logging.info("No file path entered.")
+                return
+            if not Path(file_path):
+                logging.info("File does not exist.")
+                return
+            else: 
+                logging.info(f"Sending {file_path} to client...")
+
+                # Obtain metadata.
+                file_name = os.path.basename(file_path)
+                file_size = os.path.getsize(file_path)
+                file_save_dir = output_dir
+                
+                # Send metadata first.
+                channel.send(f"FILE_META::{file_name}:{file_size}:{file_save_dir}")
+
+                # Send file in chunks (32 KB).
+                with open(file_path, "rb") as file:
+                    logging.info(f"File opened: {file_path}")
+                    while chunk := file.read(CHUNK_SIZE):
+                        while channel.bufferedAmount is not None and channel.bufferedAmount > 16 * 1024 * 1024: # Wait if buffer >16MB 
+                            await asyncio.sleep(0.1)
+
+                        channel.send(chunk)
+
+                channel.send("END_OF_FILE")
+                logging.info(f"File sent to client.")
+                
+            return
+        
+
+        @pc.on("iceconnectionstatechange")
+        async def on_iceconnectionstatechange():
+            """Logs the ICE connection state and handles connection state changes.
+
+            Args:
+                None
+            Returns:
+                None
+            """
+
+            logging.info(f"ICE connection state is now {pc.iceConnectionState}")
+            if pc.iceConnectionState == "failed":
+                logging.ERROR('ICE connection failed')
+                await clean_exit(pc, websocket)
+                return
+            elif pc.iceConnectionState in ["failed", "disconnected", "closed"]:
+                logging.info(f"ICE connection {pc.iceConnectionState}. Waiting for reconnect...")
+                for i in range(90):  # Wait up to 90 seconds
+                    await asyncio.sleep(1)
+                    if pc.iceConnectionState in ["connected", "completed"]:
+                        logging.info("ICE reconnected!")
+                        return
+
+                logging.error("Reconnection timed out. Closing connection.")
+                await clean_exit(pc, websocket)
+            else:
+                await clean_exit(pc, websocket)
+            
+        @channel.on("open")
+        def on_channel_open():
+            """Logs the channel open event.
+
+            Args:
+                None
+            Returns:
+                None
+            """
+
+            asyncio.create_task(keep_ice_alive(channel))
+            logging.info(f'{channel.label} channel is open')
+        
+        @channel.on("message")
+        async def on_message(message):
+            """Handles incoming messages from the client.
+
+            Args:
+                message: The message received from the client (can be string or bytes)
+            Returns:
+                None
+            """
+
+            # Receive client message.
+            logging.info(f"Worker received: {message}")
+
+            # Global received_files dictionary.
+            global received_files
+            global output_dir
+            global ctrl_socket
+            
+            if isinstance(message, str):
+                if message == b"KEEP_ALIVE":
+                    logging.info("Keep alive message received.")
+                    return
+
+                if message == "END_OF_FILE":
+                    logging.info("End of file transfer received.")
+
+                    # File transfer complete, save to disk.
+                    file_name, file_data = list(received_files.items())[0]
+                    file_path = os.path.join(SAVE_DIR, file_name)
+
+                    with open(file_path, "wb") as file:
+                        file.write(file_data)
+                    logging.info(f"File saved as: {file_path}")
+
+                    # Unzip results if needed.
+                    if file_path.endswith(".zip"):
+                        await unzip_results(file_path)
+                        logging.info(f"Unzipped results from {file_path}")
+
+                    # Reset dictionary for next file and train model.
+                    received_files.clear()
+
+                    train_script_path = os.path.join(SAVE_DIR, "train-script.sh")
+
+                    if Path(train_script_path):
+                        try:
+                            # Start ZMQ progress listener.
+                            progress_listener_task = asyncio.create_task(start_progress_listener(channel))
+                            logging.info(f'{channel.label} progress listener started')
+
+                            # Start ZMQ control socket.
+                            start_zmq_control()
+                            logging.info(f'{channel.label} ZMQ control socket started')
+                            
+                            # Give SUB socket time to connect.
+                            await asyncio.sleep(1)
+
+                            logging.info(f"Running training script: {train_script_path}")
+
+                            # Make the script executable
+                            os.chmod(train_script_path, os.stat(train_script_path).st_mode | stat.S_IEXEC)
+
+                            # Run the training script in the save directory
+                            process = await asyncio.create_subprocess_exec(
+                                "bash", "train-script.sh",
+                                stdout=asyncio.subprocess.PIPE,
+                                stderr=asyncio.subprocess.STDOUT,
+                                cwd=SAVE_DIR
+                            )
+
+                            assert process.stdout is not None
+                            
+                            async def stream_logs():
+                                async for line in process.stdout:
+                                    decoded_line = line.decode().rstrip()
+                                    logging.info(decoded_line)
+
+                                    if channel.readyState == "open":
+                                        try:
+                                            channel.send(f"TRAIN_LOG:{decoded_line}")
+                                        except Exception as e:
+                                            logging.error(f"Failed to send log line: {e}")
+
+                            # Run log streaming and wait for process to finish
+                            await stream_logs()
+                            await process.wait()
+
+                            logging.info("Training completed successfully.")
+                            progress_listener_task.cancel()
+                            logging.info("Zipping results...")
+
+                            # Zip the results.
+                            zipped_file_name = f"trained_{file_name}"
+                            await zip_results(zipped_file_name, f"{SAVE_DIR}/{output_dir}")
+
+                            # Send the zipped file to the client.
+                            logging.info(f"Sending zipped file to client: {zipped_file_name}")
+                            await send_worker_file(zipped_file_name)
+
+                        except subprocess.CalledProcessError as e:
+                            logging.error(f"Training failed with error:\n{e.stderr}")
+                            await clean_exit(pc, websocket)
+                    else:
+                        logging.info(f"No training script found in {SAVE_DIR}. Skipping training.")
+
+                elif "OUTPUT_DIR::" in message:
+                    logging.info(f"Output directory received: {message}")
+                    _, output_dir = message.split("OUTPUT_DIR::", 1)
+
+                elif "FILE_META::" in message:
+                    logging.info(f"File metadata received: {message}")
+                    _, meta = message.split("FILE_META::", 1)
+                    file_name, file_size = meta.split(":")
+
+                    received_files[file_name] = bytearray()
+                    logging.info(f"File name received: {file_name}, of size {file_size}")
+                elif "ZMQ_CTRL::" in message:
+                    logging.info(f"ZMQ control message received: {message}")
+                    _, zmq_msg = message.split("ZMQ_CTRL::", 1)
+                    
+                    # ProgressListenerZMQ listens on zmq_address, send updates there.
+                    # Should be either stop or cancel training cmd.
+                    if ctrl_socket != None:
+                        ctrl_socket.send_string(zmq_msg)
+                    else:
+                        logging.error(f"ZMQ control socket not initialized {ctrl_socket}. Cannot send control message.")
+                    
+                    # Update the client with the control message.
+                    channel.send(f"ZMQ_CTRL::{zmq_msg}")
+                else:
+                    logging.info(f"Client sent: {message}")
+                    await send_worker_messages(channel, pc, websocket)
+
+            elif isinstance(message, bytes):
+                if message == b"KEEP_ALIVE":
+                    logging.info("Keep alive message received.")
+                    return
+                
+                file_name = list(received_files.keys())[0]
+                received_files.get(file_name).extend(message)
+
+
+    # Establish a WebSocket connection to the signaling server.
+    async with websockets.connect(f"{DNS}:{port_number}") as websocket:
+
+        # Register the worker with the server.
+        await websocket.send(json.dumps({'type': 'register', 'peer_id': peer_id}))
+        logging.info(f"{peer_id} sent to signaling server for registration!")
+
+        # Handle incoming messages from server (e.g. answers).
+        await handle_connection(pc, websocket)
+        logging.info(f"{peer_id} connected with client!")
+
+
+    @pc.on("iceconnectionstatechange")
+    async def on_iceconnectionstatechange():
+        """Handles ICE connection state changes.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+        
+        # Log the ICE connection state.
+        logging.info(f"ICE connection state is now {pc.iceConnectionState}")
+
+        # Check the ICE connection state and handle accordingly.
+        if pc.iceConnectionState == "failed":
+            logging.ERROR('ICE connection failed')
+            await clean_exit(pc, websocket)
+            return
+        elif pc.iceConnectionState in ["failed", "disconnected", "closed"]:
+            logging.info(f"ICE connection {pc.iceConnectionState}. Waiting for reconnect...")
+
+            # Wait up to 90 seconds.
+            for i in range(90):  
+                await asyncio.sleep(1)
+                if pc.iceConnectionState in ["connected", "completed"]:
+                    logging.info("ICE reconnected!")
+                    return
+
+            logging.error("Reconnection timed out. Closing connection.")
+            await clean_exit(pc, websocket)
+        else:
+            await clean_exit(pc, websocket)
+    
+        
+if __name__ == "__main__":
+    pc = RTCPeerConnection()
+    DNS = sys.argv[1] if len(sys.argv) > 1 else "ws://ec2-54-176-92-10.us-west-1.compute.amazonaws.com"
+    port_number = sys.argv[2] if len(sys.argv) > 1 else 8080
+    try:
+        asyncio.run(run_worker(pc, "worker1", DNS, port_number))
+    except KeyboardInterrupt:
+        logging.info("KeyboardInterrupt: Exiting...")
+    finally:
+        logging.info("exited")
+        
+
+    

--- a/sleap_RTC/worker/worker_class.py
+++ b/sleap_RTC/worker/worker_class.py
@@ -1,0 +1,772 @@
+import asyncio
+import boto3
+import base64
+import subprocess
+import stat
+import sys
+import uuid
+import websockets
+import json
+import logging
+import shutil
+import os
+import re
+import requests
+import zmq
+
+from aiortc import RTCPeerConnection, RTCSessionDescription, RTCDataChannel
+# from run_training import run_all_training_jobs
+from pathlib import Path
+from websockets.client import ClientConnection
+
+# Setup logging.
+logging.basicConfig(level=logging.INFO)
+
+class RTCWorkerClient:
+    def __init__(self, remote_save_dir="/app/shared_data", chunk_size=32 * 1024):
+        self.save_dir = remote_save_dir
+        self.chunk_size = chunk_size
+        self.received_files = {}
+        self.output_dir = ""
+        self.ctrl_socket = None
+        self.pc = None  # RTCPeerConnection will be set later
+        self.websocket = None  # WebSocket connection will be set later
+
+
+    def generate_session_string(self, room_id: str, token: str, peer_id: str):
+        """Generates an encoded session string for the room."""
+        session_data = {
+            "r": room_id, 
+            "t": token, 
+            "p": peer_id 
+        }
+        encoded = base64.urlsafe_b64encode(json.dumps(session_data).encode()).decode()
+
+        return f"sleap-session:{encoded}"
+
+
+    def request_create_room(self, id_token):
+        """Requests the signaling server to create a room and returns the room ID and token.
+
+        Args:
+            id_token (str): Firebase ID token for authentication.
+        Returns:
+            dict: Contains room_id and token if successful, otherwise raises an exception.
+        """
+        
+        # Port 8001 for server_routes.py
+        # CHANGE TO EC2 INSTANCE DNS LATER
+        url = "http://ec2-54-176-92-10.us-west-1.compute.amazonaws.com:8001/create-room"
+        headers = {"Authorization": f"Bearer {id_token}"} # Use the ID token string for authentication
+
+        response = requests.post(url, headers=headers)
+        
+        if response.status_code == 200:
+            return response.json()
+        else:
+            logging.error(f"Failed to create room: {response.status_code} - {response.text}")
+            raise Exception("Failed to create room")
+
+
+    def request_anonymous_signin(self) -> str:
+        """Request an anonymous token from Signaling Server."""
+        
+        # CHANGE TO EC2 INSTANCE DNS LATER
+        url = "http://ec2-54-176-92-10.us-west-1.compute.amazonaws.com:8001/anonymous-signin"
+        response = requests.post(url)
+
+        if response.status_code == 200:
+            return response.json()["id_token"] # should be string type
+        else:
+            logging.error(f"Failed to get anonymous token: {response.text}")
+            return None
+
+
+    def parse_training_script(self, training_script_path: str):
+        jobs = []
+        pattern = re.compile(r"^\s*sleap-train\s+([^\s]+)\s+([^\s]+)")
+
+        with open(training_script_path, "r") as f:
+            for line in f:
+                match = pattern.match(line)
+                if match:
+                    config, labels = match.groups()
+                    jobs.append((config.strip(), labels.strip()))
+        return jobs
+
+
+    async def run_all_training_jobs(self, channel: RTCDataChannel, train_script_path: str, save_dir: str):
+        training_jobs = self.parse_training_script(train_script_path)
+
+        for config_name, labels_name in training_jobs:
+            job_name = Path(config_name).stem
+
+            # Send RTC msg over channel to indicate job start.
+            logging.info(f"Starting training job: {job_name} with config: {config_name} and labels: {labels_name}")
+            channel.send(f"TRAIN_JOB_START::{job_name}")
+
+            cmd = [
+                "sleap-train",
+                config_name,
+                labels_name,
+                "--zmq",
+                "--controller_port",
+                "9000",
+                "--publish_port",
+                "9001"
+            ]
+            logging.info(f"[RUNNING] {' '.join(cmd)}")
+
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=save_dir
+            )
+
+            assert process.stdout is not None
+
+            async def stream_logs():
+                async for line in process.stdout:
+                    decoded_line = line.decode().rstrip()
+                    logging.info(decoded_line)
+
+                    if channel.readyState == "open":
+                        try:
+                            channel.send(f"TRAIN_LOG:{decoded_line}")
+                        except Exception as e:
+                            logging.error(f"Failed to send log line: {e}")
+
+            await stream_logs()
+            await process.wait()
+
+            if process.returncode == 0:
+                logging.info(f"[DONE] Job {job_name} completed successfully.")
+                if channel.readyState == "open":
+                    channel.send(f"TRAIN_JOB_END::{job_name}")
+            else:
+                logging.warning(f"[FAILED] Job {job_name} exited with code {process.returncode}.")
+                if channel.readyState == "open":
+                    channel.send(f"TRAIN_JOB_ERROR::{job_name}::{process.returncode}")
+
+            # try:
+            #     subprocess.run([
+            #         "sleap-train",
+            #         config_name,
+            #         labels_name,
+            #         "--zmq",
+            #         "--controller_port",
+            #         "9000",
+            #         "--publish_port",
+            #         "9001"
+            #     ], check=True)
+            # except subprocess.CalledProcessError as e:
+            #     channel.send(f"TRAIN_JOB_ERROR::{job_name}::{e.stderr}")
+            #     logging.error(f"Training job {job_name} failed with error: {e.stderr}")
+            #     continue
+
+            # channel.send(f"TRAIN_JOB_END::{job_name}")
+
+        channel.send("TRAINING_JOBS_DONE")
+
+
+    def start_zmq_control(self, zmq_address: str = "tcp://127.0.0.1:9000"):
+        """Starts a ZMQ control PUB socket to send ZMQ commands to the Trainer.
+    
+        Args:
+            zmq_address: Address of the ZMQ socket to connect to.
+        Returns:
+            None
+        """
+        # Initialize socket and event loop.
+        logging.info("Starting ZMQ control socket...")
+        context = zmq.Context()
+        socket = context.socket(zmq.PUB)
+
+        logging.info(f"Connecting to ZMQ address: {zmq_address}")
+        socket.bind(zmq_address)
+
+        # set PUB socket for use in other functions
+        self.ctrl_socket = socket
+        logging.info("ZMQ control socket initialized.")
+
+    async def start_progress_listener(self, channel: RTCDataChannel, zmq_address: str = "tcp://127.0.0.1:9001"):
+        """Starts a listener for ZMQ messages and sends progress updates to the client over the data channel.
+    
+        Args:
+            channel: DataChannel object to send progress updates.
+            zmq_address: Address of the ZMQ socket to connect to.
+        Returns:
+            None
+        """
+
+        # Initialize socket and event loop.
+        logging.info("Starting ZMQ progress listener...")
+        context = zmq.Context()
+        socket = context.socket(zmq.SUB)
+
+        logging.info(f"Connecting to ZMQ address: {zmq_address}")
+        socket.bind(zmq_address) 
+        socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        loop = asyncio.get_event_loop()
+
+        def recv_msg():
+            """Receives a message from the ZMQ socket in a non-blocking way.
+            
+            Returns:
+                The received message as a JSON object, or None if no message is available.
+            """
+            
+            try:
+                # logging.info("Receiving message from ZMQ...")
+                return socket.recv_string(flags=zmq.NOBLOCK)  # or jsonpickle.decode(msg_str) if needed
+            except zmq.Again:
+                return None
+
+        while True:
+            # Send progress as JSON string with prefix.
+            msg = await loop.run_in_executor(None, recv_msg)
+
+            if msg:
+                try:
+                    logging.info(f"Sending progress report to client: {msg}")
+                    channel.send(f"PROGRESS_REPORT::{msg}")
+                    # logging.info("Progress report sent to client.")
+                except Exception as e:
+                    logging.error(f"Failed to send ZMQ progress: {e}")
+                    
+            # Polling interval.
+            await asyncio.sleep(0.05)
+
+    async def zip_results(self, file_name: str, dir_path: str = None):
+        """Zips the contents of the shared_data directory and saves it to a zip file.
+
+        Args:
+            file_name: Name of the zip file to be created.
+            dir_path: Path to the directory to be zipped.
+        Returns:
+            None
+        """
+
+        if dir_path is None:
+            dir_path = self.save_dir
+
+        logging.info("Zipping results...")
+        if Path(dir_path):
+            try:
+                shutil.make_archive(file_name.split(".")[0], 'zip', dir_path)
+                logging.info(f"Results zipped to {file_name}")
+            except Exception as e:
+                logging.error(f"Error zipping results: {e}")
+                return
+        else:
+            logging.info(f"{dir_path} does not exist!")
+            return
+
+    async def unzip_results(self, file_path: str, dir_path: str = None):
+        """Unzips the contents of the given file path.
+
+        Args:
+            file_path: Path to the zip file to be unzipped.
+        Returns:
+            None
+        """
+
+        if dir_path is None:
+            dir_path = self.save_dir
+
+        logging.info("Unzipping results...")
+        if Path(file_path):
+            try:
+                shutil.unpack_archive(file_path, dir_path)
+                logging.info(f"Results unzipped from {file_path}")
+            except Exception as e:
+                logging.error(f"Error unzipping results: {e}")
+                return
+        else:
+            logging.info(f"{file_path} does not exist!")
+            return
+        
+    async def clean_exit(self):
+        """Handles cleanup and shutdown of the worker.
+
+        Args:
+            pc: RTCPeerConnection object
+            websocket: WebSocket connection object
+        Returns:
+            None    
+        """
+
+        logging.info("Closing WebRTC connection...") 
+        await self.pc.close()
+
+        logging.info("Closing websocket connection...")
+        await self.websocket.close()
+
+        logging.info("Client shutdown complete. Exiting...")
+
+    async def send_worker_messages(self, pc: RTCPeerConnection, channel: RTCDataChannel):
+        """Handles typed messages from worker to be sent to client peer.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+
+        message = input("Enter message to send (type 'file' to prompt file or type 'quit' to exit): ")
+        data = None
+        
+        if message.lower() == "quit":
+            logging.info("Quitting...")
+            await pc.close()
+            return
+
+        if channel.readyState != "open":
+            logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+            return
+
+        if message.lower() == "file":
+            logging.info("Prompting file...")
+            file_path = input("Enter file path: (or type 'quit' to exit): ")
+            if not file_path:
+                logging.info("No file path entered.")
+                return
+            if file_path.lower() == "quit":
+                logging.info("Quitting...")
+                await pc.close()
+                return
+            if not Path(file_path):
+                logging.info("File does not exist.")
+                return
+            else:
+                logging.info(f"Sending {file_path} to client...")
+                file_name = os.path.basename(file_path)
+                file_size = os.path.getsize(file_path)
+                file_save_dir = self.output_dir 
+                
+                # Send metadata first
+                channel.send(f"FILE_META::{file_name}:{file_size}:{file_save_dir}")
+                
+                # Send file in chunks (32 KB)
+                with open(file_path, "rb") as file:
+                    logging.info(f"File opened: {file_path}")
+                    while chunk := file.read(self.CHUNK_SIZE):
+                        channel.send(chunk)
+                
+                channel.send("END_OF_FILE")
+                logging.info(f"File sent to client.")
+                        
+                # Flag data to True to prevent reg msg from being sent
+                data = True
+
+        if not data:
+            channel.send(message)
+            logging.info(f"Message sent to client.")
+
+    async def handle_connection(self, pc: RTCPeerConnection, websocket: ClientConnection, peer_id: str):
+        """ Handles incoming messages from the signaling server and processes them accordingly.
+
+        Args:
+            pc: RTCPeerConnection object
+            websocket: WebSocket connection object
+            peer_id: The ID of the peer
+        Returns:
+            None    
+        """
+
+        if websocket is None:
+            logging.info("Given websocket is None. Using self.websocket instead.")
+
+        if pc is None:
+            logging.info("Given PeerConnection object is None. Using self.pc instead.")
+ 
+
+        try:
+            async for message in self.websocket:
+                data = json.loads(message)
+                msg_type = data.get('type')
+
+                # Receive offer SDP from client (forwarded by signaling server).
+                if msg_type == "offer":
+                    logging.info('Received offer SDP')
+
+                    # Obtain the sender's peer ID (this is the new target)
+                    target_pid = data.get('sender')
+
+                    # Set worker peer's remote description to the client's offer based on sdp data
+                    await self.pc.setRemoteDescription(RTCSessionDescription(sdp=data.get('sdp'), type='offer')) 
+                    
+                    # Generate worker's answer SDP and set it as the local description
+                    await self.pc.setLocalDescription(await self.pc.createAnswer())
+
+                    # Send worker's answer SDP to client so they can set it as their remote description
+                    await self.websocket.send(json.dumps({
+                        'type': self.pc.localDescription.type, # 'answer'
+                        'sender': peer_id, # worker's peer ID
+                        'target': target_pid, # client's peer ID
+                        'sdp': self.pc.localDescription.sdp # worker's answer SDP
+                    }))
+
+                    # Reset received_files dictionary
+                    self.received_files.clear()
+
+                elif msg_type == 'registered_auth':
+                    logging.info(f"Worker authenticated with server. Please copy the following session string:")
+                    session_string = self.generate_session_string(
+                        data.get('room_id'), # room ID
+                        data.get('token'), # room password
+                        data.get('peer_id') # peer's ID
+                    )
+                    logging.info(session_string)
+                    # ex. 'sleap-session:eyJyb29tX2lkIjogImFiYzEyMyIsICJ0b2tlbiI6I'
+
+                # Handle "trickle ICE" for non-local ICE candidates (might be unnecessary)
+                elif msg_type == 'candidate':
+                    print("Received ICE candidate")
+                    candidate = data.get('candidate')
+                    await pc.addIceCandidate(candidate)
+
+                elif msg_type == 'error':
+                    logging.error(f"Error received from server: {data.get('reason')}")
+                    await self.clean_exit()
+                    return
+
+                elif msg_type == 'quit': # NOT initiator, received quit request from worker
+                    print("Received quit request from Client. Closing connection...")
+                    await self.clean_exit()
+                    return
+
+                # Error handling
+                else:
+                    logging.ERROR(f"Unhandled message: {data}")
+                    
+        
+        except json.JSONDecodeError:
+            logging.ERROR("Invalid JSON received")
+
+        except Exception as e:
+            logging.ERROR(f"Error handling message: {e}")
+
+    async def keep_ice_alive(self, channel: RTCDataChannel):
+        """Sends periodic keep-alive messages to the client to maintain the connection.
+        
+        Args:
+            channel: DataChannel object
+        Returns:
+            None
+        """
+
+        while True:
+            await asyncio.sleep(15)
+            if channel.readyState == "open":
+                channel.send(b"KEEP_ALIVE")
+
+    # Websockets are only necessary here for setting up exchange of SDP & ICE candidates to each other.
+    # Listen for incoming data channel messages on channel established by the client.         
+    def on_datachannel(self, channel: RTCDataChannel):
+        """Handles incoming data channel messages from the client.
+
+        Args:
+            channel: DataChannel object
+        Returns: 
+            None
+        """
+
+        # Listen for incoming messages on the channel.
+        logging.info("channel(%s) %s" % (channel.label, "created by remote party & received."))
+    
+        async def send_worker_file(file_path: str):
+            """Handles direct, one-way file transfer from client to be sent to client peer.
+        
+            Args:
+                file_path: Path to the file to be sent.
+            Returns:
+                None
+            """
+            
+            if channel.readyState != "open":
+                logging.info(f"Data channel not open. Ready state is: {channel.readyState}")
+                return 
+
+            logging.info(f"Given file path {file_path}")
+            if not file_path:
+                logging.info("No file path entered.")
+                return
+            if not Path(file_path):
+                logging.info("File does not exist.")
+                return
+            else: 
+                logging.info(f"Sending {file_path} to client...")
+
+                # Obtain metadata.
+                file_name = os.path.basename(file_path)
+                file_size = os.path.getsize(file_path)
+                file_save_dir = self.output_dir
+                
+                # Send metadata first.
+                channel.send(f"FILE_META::{file_name}:{file_size}:{file_save_dir}")
+
+                # Send file in chunks (32 KB).
+                with open(file_path, "rb") as file:
+                    logging.info(f"File opened: {file_path}")
+                    while chunk := file.read(self.chunk_size):
+                        while channel.bufferedAmount is not None and channel.bufferedAmount > 16 * 1024 * 1024: # Wait if buffer >16MB 
+                            await asyncio.sleep(0.1)
+
+                        channel.send(chunk)
+
+                channel.send("END_OF_FILE")
+                logging.info(f"File sent to client.")
+                
+            return
+            
+        @channel.on("open")
+        def on_channel_open():
+            """Logs the channel open event.
+
+            Args:
+                None
+            Returns:
+                None
+            """
+
+            asyncio.create_task(self.keep_ice_alive(channel))
+            logging.info(f'{channel.label} channel is open')
+        
+        @channel.on("message")
+        async def on_message(message):
+            """Handles incoming messages from the client.
+
+            Args:
+                message: The message received from the client (can be string or bytes)
+            Returns:
+                None
+            """
+
+            # Log Client's message.
+            logging.info(f"Worker received: {message}")
+            
+            if isinstance(message, str):
+                if message == b"KEEP_ALIVE":
+                    logging.info("Keep alive message received.")
+                    return
+
+                if message == "END_OF_FILE":
+                    logging.info("End of file transfer received.")
+
+                    # File transfer complete, save to disk.
+                    file_name, file_data = list(self.received_files.items())[0]
+                    file_path = os.path.join("", file_name)
+
+                    with open(file_path, "wb") as file:
+                        file.write(file_data)
+                    logging.info(f"File saved as: {file_path}")
+
+                    # Unzip results if needed.
+                    if file_path.endswith(".zip"):
+                        await self.unzip_results(file_path)
+                        logging.info(f"Unzipped results from {file_path}")
+
+                    # Reset dictionary for next file and train model.
+                    self.received_files.clear()
+
+                    train_script_path = os.path.join(self.save_dir, "train-script.sh")
+
+                    if Path(train_script_path):
+                        try:
+                            # Start ZMQ progress listener.
+                            progress_listener_task = asyncio.create_task(self.start_progress_listener(channel))
+                            logging.info(f'{channel.label} progress listener started')
+
+                            # Start ZMQ control socket.
+                            self.start_zmq_control()
+                            logging.info(f'{channel.label} ZMQ control socket started')
+                            
+                            # Give SUB socket time to connect.
+                            await asyncio.sleep(1)
+
+                            logging.info(f"Running training script: {train_script_path}")
+
+                            # Make the script executable
+                            os.chmod(train_script_path, os.stat(train_script_path).st_mode | stat.S_IEXEC)
+
+                            # Run the training script in the save directory
+                            await self.run_all_training_jobs(channel, train_script_path=train_script_path, save_dir=self.save_dir)
+
+                            # Finish training.
+                            logging.info("Training completed successfully.")
+                            progress_listener_task.cancel()
+
+                            # Zip the results.
+                            logging.info("Zipping results...")
+                            zipped_file_name = f"trained_{file_name}"
+                            await self.zip_results(zipped_file_name, f"{self.save_dir}/{self.output_dir}") # normally, "/app/shared_data /models"
+
+                            # Send the zipped file to the client.
+                            logging.info(f"Sending zipped file to client: {zipped_file_name}")
+                            await send_worker_file(zipped_file_name)
+
+                        except subprocess.CalledProcessError as e:
+                            logging.error(f"Training failed with error:\n{e.stderr}")
+                            await self.clean_exit()
+                    else:
+                        logging.info(f"No training script found in {self.save_dir}. Skipping training.")
+
+                elif "OUTPUT_DIR::" in message:
+                    logging.info(f"Output directory received: {message}")
+                    _, self.output_dir = message.split("OUTPUT_DIR::", 1) # normally, "models"
+
+                elif "FILE_META::" in message:
+                    logging.info(f"File metadata received: {message}")
+                    _, meta = message.split("FILE_META::", 1)
+                    file_name, file_size = meta.split(":")
+
+                    self.received_files[file_name] = bytearray()
+                    logging.info(f"File name received: {file_name}, of size {file_size}")
+                elif "ZMQ_CTRL::" in message:
+                    logging.info(f"ZMQ LossViewer control message received: {message}")
+                    _, zmq_msg = message.split("ZMQ_CTRL::", 1)
+
+                    # Send LossViewer's control message to the Trainer client (listening on control port 9000).
+                    # Remember, the Trainer printed: "ZMQ controller subscribed to: tcp://127.0.0.1:9000", so publish there.
+                    if self.ctrl_socket != None:
+                        self.ctrl_socket.send_string(zmq_msg)
+                        logging.info(f"Sent control message to Trainer: {zmq_msg}")
+                    else:
+                        logging.error(f"ZMQ control socket not initialized {self.ctrl_socket}. Cannot send control message.")
+                    
+
+                else:
+                    logging.info(f"Client sent: {message}")
+                    await self.send_worker_messages(channel, self.pc, self.websocket)
+
+            elif isinstance(message, bytes):
+                if message == b"KEEP_ALIVE":
+                    logging.info("Keep alive message received.")
+                    return
+                
+                file_name = list(self.received_files.keys())[0]
+                self.received_files.get(file_name).extend(message)
+
+    async def on_iceconnectionstatechange(self):
+        """Handles ICE connection state changes.
+
+        Args:
+            None
+        Returns:
+            None
+        """
+        
+        # Log the ICE connection state.
+        logging.info(f"ICE connection state is now {self.pc.iceConnectionState}")
+
+        # Check the ICE connection state and handle accordingly.
+        if self.pc.iceConnectionState == "failed":
+            logging.ERROR('ICE connection failed')
+            await self.clean_exit()
+            return
+        elif self.pc.iceConnectionState in ["failed", "disconnected", "closed"]:
+            logging.info(f"ICE connection {self.pc.iceConnectionState}. Waiting for reconnect...")
+
+            # Wait up to 90 seconds.
+            for i in range(90):  
+                await asyncio.sleep(1)
+                if self.pc.iceConnectionState in ["connected", "completed"]:
+                    logging.info("ICE reconnected!")
+                    return
+
+            logging.error("Reconnection timed out. Closing connection.")
+            await self.clean_exit()
+            
+        elif self.pc.iceConnectionState == "checking":
+            logging.info("ICE connection is checking...")
+            
+
+    async def run_worker(self, pc, peer_id: str, DNS: str, port_number):
+        """Main function to run the worker. Contains several event handlers for the WebRTC connection and data channel.
+        
+        Args:
+            pc: RTCPeerConnection object
+            peer_id: ID of the worker peer
+            DNS: DNS address of the signaling server
+            port_number: Port number of the signaling server
+        Returns:
+            None
+        """
+
+        # Set the RTCPeerConnection object for the worker.
+        logging.info(f"Setting RTCPeerConnection for {peer_id}...")
+        self.pc = pc
+
+        # Register PeerConnection functions with PC object.
+        logging.info(f"Registering PeerConnection functions for {peer_id}...")
+        self.pc.on("datachannel", self.on_datachannel)
+        self.pc.on("iceconnectionstatechange", self.on_iceconnectionstatechange)
+
+        # Sign-in anonymously with AWS Cognito to get an ID token (str).
+        id_token = self.request_anonymous_signin()
+        
+        if not id_token:
+            logging.error("Failed to sign in anonymously. No ID token given. Exiting...")
+            return
+        
+        logging.info(f"Anonymous sign-in successful. ID token: {id_token}")
+       
+        # Create the room and get the room ID and token.
+        room_json = self.request_create_room(id_token)
+
+        if not room_json or 'room_id' not in room_json or 'token' not in room_json:
+            logging.error("Failed to create room or get room ID/token. Exiting...")
+            return
+        logging.info(f"Room created with ID: {room_json['room_id']} and token: {room_json['token']}")
+
+        # Establish a WebSocket connection to the signaling server.
+        logging.info(f"Connecting to signaling server at {DNS}:{port_number}...")
+        async with websockets.connect(f"{DNS}:{port_number}") as websocket:
+
+            # Set the WebSocket connection for the worker.
+            self.websocket = websocket
+
+            # Register the worker with the server.
+            logging.info(f"Registering {peer_id} with signaling server...")
+            await self.websocket.send(json.dumps({
+                'type': 'register', 
+                'peer_id': peer_id, # identify a peer uniquely in the room (Zoom username)
+                'room_id': room_json['room_id'], # from backend API call for room identification (Zoom meeting ID)
+                'token': room_json['token'], # from backend API call for room joining (Zoom meeting password)
+                'id_token': id_token, # from anon. Cognito sign-in (Prevent peer spoofing, even anonymously)
+                # w/ id_token, only Cognito authenticated users can register.
+            }))
+            logging.info(f"{peer_id} sent to signaling server for registration!")
+
+            # Handle incoming messages from server (e.g. answers).
+            await self.handle_connection(self.pc, self.websocket, peer_id)
+            logging.info(f"{peer_id} connected with client!")
+
+if __name__ == "__main__":
+    # Create the worker instance.
+    worker = RTCWorkerClient()
+
+    # Create the RTCPeerConnection object.
+    pc = RTCPeerConnection()
+
+    # Generate a unique peer ID for the worker.
+    peer_id = f"worker-{uuid.uuid4()}"
+
+    # Run the worker 
+    try:
+        asyncio.run(
+            worker.run_worker(
+                pc=pc,
+                peer_id=peer_id,
+                DNS="ws://ec2-54-176-92-10.us-west-1.compute.amazonaws.com",
+                port_number=8080
+            )
+        )
+    except KeyboardInterrupt:
+        logging.info("Worker interrupted by user. Shutting down...")
+    finally:
+        logging.info("Worker exiting...")
+

--- a/sleap_RTC/worker/zmq_check.py
+++ b/sleap_RTC/worker/zmq_check.py
@@ -1,0 +1,83 @@
+import zmq
+import threading
+import time
+import json
+
+# Fake RTC data channel
+class DummyRTCChannel:
+    """A dummy class to simulate a WebRTC data channel."""
+
+    def __init__(self):
+        self.readyState = "open"
+
+    def send(self, msg):
+        """Simulate sending a message over the WebRTC data channel.
+
+        Args:
+            msg (str): The message to send.
+        Raises:
+            RuntimeError: If the channel is not open.   
+        """
+        print(f"[RTC SEND] {msg}")
+
+# Fake ZMQ PUB publisher to simulate sleap-train
+def simulate_training_pub(zmq_address):
+    """Simulate a ZMQ PUB publisher that sends training progress updates.
+
+    Args:
+        zmq_address (str): The ZMQ address to bind the publisher socket to.
+    Raises:
+        RuntimeError: If the publisher fails to bind to the ZMQ address.
+    """
+
+    ctx = zmq.Context()
+    pub_socket = ctx.socket(zmq.PUB)
+    pub_socket.bind(zmq_address)
+
+    # Give SUB time to connect
+    time.sleep(1)
+
+    for i in range(5):
+        update = json.dumps({"epoch": i, "loss": round(1.0 / (i + 1), 4)})
+        print(f"[PUB] Sending: {update}")
+        pub_socket.send_string(update)
+        time.sleep(1)
+
+# Your real ZMQ listener (the one inside Worker)
+def start_progress_listener(zmq_address, rtc_channel):
+    """Start a ZMQ SUB listener that receives training progress updates.
+
+    Args:
+        zmq_address (str): The ZMQ address to connect the subscriber socket to.
+        rtc_channel (DummyRTCChannel): The dummy RTC channel to send updates to.
+    Raises:
+        RuntimeError: If the subscriber fails to connect to the ZMQ address.
+    """
+
+    ctx = zmq.Context()
+    sub_socket = ctx.socket(zmq.SUB)
+    sub_socket.connect(zmq_address)
+    sub_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+    print("[SUB] Connected. Waiting for messages...")
+    while True:
+        msg = sub_socket.recv_string()
+        print(f"[SUB] Received: {msg}")
+        if rtc_channel.readyState == "open":
+            rtc_channel.send(f"TRAIN_PROGRESS:{msg}")
+        else:
+            print("[RTC] Data channel not open.")
+
+# Main entrypoint.
+if __name__ == "__main__":
+    zmq_address = "tcp://127.0.0.1:9001"
+    rtc_channel = DummyRTCChannel()
+
+    # Start fake training publisher.
+    threading.Thread(target=start_progress_listener, args=(zmq_address, rtc_channel), daemon=True).start()
+
+    # Give SUB socket time to fully connect/subscribe.
+    time.sleep(1)
+
+    # Start progress listener.
+    simulate_training_pub(zmq_address)


### PR DESCRIPTION
This PR moves the working sleap-RTC Client and Worker classes from their respective repos into one repo. This is in order to setup for Client and Worker classes/commands. The server will be excluded from this repo, since this package is intended for Client & Worker set-up (we will host the server separately on the dedicated EC2 instance). 

Notes:
- Setup for:
- Anybody can install sleap-rtc and do something like 'uv run sleap-rtc-worker' or 'sleap-rtc-worker' in their terminal
- Anybody can install sleap-rtc as a package and import 'sleap-rtc-worker' to use classes and functions (i.e. in SLEAP)