### PR TITLE
E2E encryption for relay transport (ECDH P-256 + AES-256-GCM)

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -145,6 +145,12 @@ class SleapRTCDashboard {
 
         // Active job tracking
         this.activeJobs = new Map(); // jobId → job state
+
+        // E2E encryption state (per-session, cleared on page refresh)
+        this._e2eSessionId = null;
+        this._e2ePrivateKey = null;  // CryptoKey (P-256 ECDH)
+        this._e2eSharedKey = null;   // CryptoKey (AES-256-GCM)
+        this._e2eReady = false;
         this._workerPollInterval = null;
 
         this.init();
@@ -662,10 +668,25 @@ class SleapRTCDashboard {
         const url = `${CONFIG.RELAY_SERVER}/stream/${encodeURIComponent(channel)}`;
         const es = new EventSource(url);
         const handlers = {};
+        const dashboard = this;
 
-        es.onmessage = (event) => {
+        es.onmessage = async (event) => {
             let data;
             try { data = JSON.parse(event.data); } catch { return; }
+
+            // Handle encrypted relay messages — decrypt and re-dispatch
+            if (data.type === 'encrypted_relay') {
+                if (!dashboard._e2eReady || !dashboard._e2eSharedKey) {
+                    return; // No key yet, discard
+                }
+                if (data.session_id !== dashboard._e2eSessionId) {
+                    return; // Stale session, discard
+                }
+                const decrypted = await dashboard._e2eDecrypt(data.nonce, data.ciphertext);
+                if (!decrypted) return; // Decryption failed, discard silently
+                data = decrypted;
+            }
+
             const type = data.type;
             if (type && handlers[type]) handlers[type](data);
             if (handlers['*']) handlers['*'](data);
@@ -682,13 +703,173 @@ class SleapRTCDashboard {
         };
     }
 
+    // =========================================================================
+    // E2E Encryption for Relay Transport
+    // =========================================================================
+
+    async _e2eGenerateKeypair() {
+        const keyPair = await crypto.subtle.generateKey(
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, ['deriveBits']
+        );
+        const publicKeyRaw = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+        return { privateKey: keyPair.privateKey, publicKeyRaw };
+    }
+
+    async _e2eDeriveKey(privateKey, peerPublicKeyRaw) {
+        const peerPublicKey = await crypto.subtle.importKey(
+            'raw', peerPublicKeyRaw,
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, []
+        );
+        const sharedBits = await crypto.subtle.deriveBits(
+            { name: 'ECDH', public: peerPublicKey },
+            privateKey, 256
+        );
+        const hkdfKey = await crypto.subtle.importKey(
+            'raw', sharedBits, 'HKDF', false, ['deriveKey']
+        );
+        return crypto.subtle.deriveKey(
+            {
+                name: 'HKDF',
+                hash: 'SHA-256',
+                salt: new Uint8Array(0),
+                info: new TextEncoder().encode('sleap-rtc-relay-e2e-v1'),
+            },
+            hkdfKey,
+            { name: 'AES-GCM', length: 256 },
+            false, ['encrypt', 'decrypt']
+        );
+    }
+
+    async _e2eEncrypt(payload) {
+        const nonce = crypto.getRandomValues(new Uint8Array(12));
+        const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+        const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv: nonce },
+            this._e2eSharedKey, plaintext
+        ));
+        return {
+            nonce: btoa(String.fromCharCode(...nonce)),
+            ciphertext: btoa(String.fromCharCode(...ciphertext)),
+        };
+    }
+
+    async _e2eDecrypt(nonceB64, ciphertextB64) {
+        try {
+            const nonceBin = atob(nonceB64);
+            const nonce = new Uint8Array(nonceBin.length);
+            for (let i = 0; i < nonceBin.length; i++) nonce[i] = nonceBin.charCodeAt(i);
+            const ctBin = atob(ciphertextB64);
+            const ct = new Uint8Array(ctBin.length);
+            for (let i = 0; i < ctBin.length; i++) ct[i] = ctBin.charCodeAt(i);
+            const plaintext = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv: nonce },
+                this._e2eSharedKey, ct
+            );
+            return JSON.parse(new TextDecoder().decode(plaintext));
+        } catch (e) {
+            console.warn('[E2E] Decryption failed:', e.message);
+            return null;
+        }
+    }
+
+    async _e2eInitKeyExchange(peerId) {
+        this._e2eReady = false;
+        this._e2eSharedKey = null;
+        this._e2eSessionId = crypto.randomUUID();
+
+        const { privateKey, publicKeyRaw } = await this._e2eGenerateKeypair();
+        this._e2ePrivateKey = privateKey;
+
+        const pubBytes = new Uint8Array(publicKeyRaw);
+        const pubB64 = btoa(String.fromCharCode(...pubBytes))
+            .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+        const attempt = async () => {
+            return new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                    reject(new Error('Key exchange timeout'));
+                }, 5000);
+
+                const originalHandler = this._sjWorkerSSE?.raw?.onmessage;
+                const wrappedHandler = async (event) => {
+                    let data;
+                    try { data = JSON.parse(event.data); } catch { return; }
+
+                    if (data.type === 'key_exchange_response' &&
+                        data.session_id === this._e2eSessionId) {
+                        clearTimeout(timeout);
+
+                        let workerPubB64 = data.public_key
+                            .replace(/-/g, '+').replace(/_/g, '/');
+                        while (workerPubB64.length % 4) workerPubB64 += '=';
+                        const workerPubBin = atob(workerPubB64);
+                        const workerPubBytes = new Uint8Array(workerPubBin.length);
+                        for (let i = 0; i < workerPubBin.length; i++)
+                            workerPubBytes[i] = workerPubBin.charCodeAt(i);
+
+                        try {
+                            this._e2eSharedKey = await this._e2eDeriveKey(
+                                this._e2ePrivateKey, workerPubBytes.buffer
+                            );
+                            this._e2eReady = true;
+                            console.log(`[E2E] Key exchange complete (session ${this._e2eSessionId.slice(0, 8)}...)`);
+                            resolve(true);
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+
+                    if (originalHandler) originalHandler(event);
+                };
+
+                if (this._sjWorkerSSE?.raw) {
+                    this._sjWorkerSSE.raw.onmessage = wrappedHandler;
+                }
+
+                this.apiWorkerMessage(this._sjRoomId, peerId, {
+                    type: 'key_exchange',
+                    session_id: this._e2eSessionId,
+                    public_key: pubB64,
+                }).catch(reject);
+            });
+        };
+
+        for (let i = 0; i < 2; i++) {
+            try {
+                await attempt();
+                return true;
+            } catch (e) {
+                console.warn(`[E2E] Key exchange attempt ${i + 1} failed: ${e.message}`);
+                if (i === 0) continue;
+            }
+        }
+
+        console.error('[E2E] Key exchange failed after 2 attempts');
+        return false;
+    }
+
     /**
      * Forward an arbitrary message to a worker via the signaling server.
+     * If E2E encryption is active, the message is encrypted before sending.
      */
     async apiWorkerMessage(roomId, peerId, message) {
+        let outMessage = message;
+
+        if (this._e2eReady && this._e2eSharedKey && message.type !== 'key_exchange') {
+            const { nonce, ciphertext } = await this._e2eEncrypt(message);
+            outMessage = {
+                type: 'encrypted_relay',
+                session_id: this._e2eSessionId,
+                nonce,
+                ciphertext,
+            };
+        }
+
         return this.apiRequest('/api/worker/message', {
             method: 'POST',
-            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message }),
+            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message: outMessage }),
         });
     }
 
@@ -2490,7 +2671,7 @@ class SleapRTCDashboard {
         }
     }
 
-    sjGoToInferenceStep() {
+    async sjGoToInferenceStep() {
         // Hide all views
         ['sj-step1', 'sj-step2', 'sj-step3', 'sj-status'].forEach(id => {
             document.getElementById(id)?.classList.add('hidden');
@@ -2524,6 +2705,17 @@ class SleapRTCDashboard {
             .on('fs_list_res', (data) => this._sjHandleFsListRes(data))
             .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
             .on('worker_path_error', (data) => this._sjHandlePathError(data));
+
+        // E2E key exchange with worker
+        const inferenceError = document.getElementById('sj-inference-error');
+        const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
+        if (!e2eOk) {
+            if (inferenceError) {
+                inferenceError.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
+                inferenceError.classList.remove('hidden');
+            }
+            return;
+        }
 
         // Init icons
         const inferenceView = document.getElementById('sj-step-inference');
@@ -3434,6 +3626,18 @@ class SleapRTCDashboard {
                 .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
                 .on('worker_path_error', (data) => this._sjHandlePathError(data))
                 .on('fs_check_videos_response', (data) => this._sjHandleVideoCheck(data));
+
+            // E2E key exchange with worker
+            const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
+            if (!e2eOk) {
+                document.getElementById('sj-browser-spinner')?.classList.add('hidden');
+                const errEl = document.getElementById('sj-browser-error');
+                if (errEl) {
+                    errEl.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
+                    errEl.classList.remove('hidden');
+                }
+                return;
+            }
 
             // Re-fetch worker data to get fresh metadata (mounts may change after reconnection)
             await this.loadRoomWorkers(this._sjRoomId);

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -2739,7 +2739,7 @@ class SleapRTCDashboard {
         // DEBUG: log activeJobs state so we can verify worker status derivation
         console.log('[DEBUG-workerStatus] _sjRenderWorkerList roomId=%s activeJobs:', this._sjRoomId,
             Array.from(this.activeJobs.entries()).map(([id, j]) =>
-                `${id.slice(0,8)} worker=${j.workerId} room=${j.roomId} status=${j.status}`));
+                `${(id || 'unknown').slice(0,8)} worker=${j?.workerId} room=${j?.roomId} status=${j?.status}`));
 
         const workers = this.roomWorkers[this._sjRoomId]?.workers ?? [];
         if (workers.length === 0) {

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -147,6 +147,12 @@ class SleapRTCDashboard {
         this.activeJobs = new Map(); // jobId → job state
         this._workerPollInterval = null;
 
+        // E2E encryption state (per-session, cleared on page refresh)
+        this._e2eSessionId = null;
+        this._e2ePrivateKey = null;  // CryptoKey (P-256 ECDH)
+        this._e2eSharedKey = null;   // CryptoKey (AES-256-GCM)
+        this._e2eReady = false;
+
         this.init();
     }
 
@@ -662,10 +668,25 @@ class SleapRTCDashboard {
         const url = `${CONFIG.RELAY_SERVER}/stream/${encodeURIComponent(channel)}`;
         const es = new EventSource(url);
         const handlers = {};
+        const dashboard = this;
 
-        es.onmessage = (event) => {
+        es.onmessage = async (event) => {
             let data;
             try { data = JSON.parse(event.data); } catch { return; }
+
+            // Handle encrypted relay messages — decrypt and re-dispatch
+            if (data.type === 'encrypted_relay') {
+                if (!dashboard._e2eReady || !dashboard._e2eSharedKey) {
+                    return; // No key yet, discard
+                }
+                if (data.session_id !== dashboard._e2eSessionId) {
+                    return; // Stale session, discard
+                }
+                const decrypted = await dashboard._e2eDecrypt(data.nonce, data.ciphertext);
+                if (!decrypted) return; // Decryption failed, discard silently
+                data = decrypted;
+            }
+
             const type = data.type;
             if (type && handlers[type]) handlers[type](data);
             if (handlers['*']) handlers['*'](data);
@@ -682,20 +703,236 @@ class SleapRTCDashboard {
         };
     }
 
+    // =========================================================================
+    // E2E Encryption for Relay Transport
+    // =========================================================================
+
+    /**
+     * Generate an ephemeral ECDH P-256 keypair for E2E encryption.
+     * @returns {Promise<{privateKey: CryptoKey, publicKeyRaw: ArrayBuffer}>}
+     */
+    async _e2eGenerateKeypair() {
+        const keyPair = await crypto.subtle.generateKey(
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, // private key not extractable
+            ['deriveBits']
+        );
+        const publicKeyRaw = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+        return { privateKey: keyPair.privateKey, publicKeyRaw };
+    }
+
+    /**
+     * Derive an AES-256-GCM key from ECDH shared secret + HKDF.
+     * Parameters must match Python side exactly.
+     * @param {CryptoKey} privateKey - Our P-256 private key
+     * @param {ArrayBuffer} peerPublicKeyRaw - Peer's raw public key (65 bytes)
+     * @returns {Promise<CryptoKey>} AES-256-GCM key
+     */
+    async _e2eDeriveKey(privateKey, peerPublicKeyRaw) {
+        const peerPublicKey = await crypto.subtle.importKey(
+            'raw', peerPublicKeyRaw,
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, []
+        );
+
+        // ECDH → shared secret
+        const sharedBits = await crypto.subtle.deriveBits(
+            { name: 'ECDH', public: peerPublicKey },
+            privateKey, 256
+        );
+
+        // Import as HKDF key material
+        const hkdfKey = await crypto.subtle.importKey(
+            'raw', sharedBits, 'HKDF', false, ['deriveKey']
+        );
+
+        // HKDF → AES-256-GCM key (must match Python: SHA-256, no salt, info="sleap-rtc-relay-e2e-v1")
+        return crypto.subtle.deriveKey(
+            {
+                name: 'HKDF',
+                hash: 'SHA-256',
+                salt: new Uint8Array(0),
+                info: new TextEncoder().encode('sleap-rtc-relay-e2e-v1'),
+            },
+            hkdfKey,
+            { name: 'AES-GCM', length: 256 },
+            false, ['encrypt', 'decrypt']
+        );
+    }
+
+    /**
+     * Encrypt a JSON payload with AES-256-GCM.
+     * @param {object} payload - JSON-serializable object
+     * @returns {Promise<{nonce: string, ciphertext: string}>} Base64-encoded nonce and ciphertext
+     */
+    async _e2eEncrypt(payload) {
+        const nonce = crypto.getRandomValues(new Uint8Array(12));
+        const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+        const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv: nonce },
+            this._e2eSharedKey, plaintext
+        ));
+        return {
+            nonce: btoa(String.fromCharCode(...nonce)),
+            ciphertext: btoa(String.fromCharCode(...ciphertext)),
+        };
+    }
+
+    /**
+     * Decrypt an AES-256-GCM ciphertext back to a JSON object.
+     * @param {string} nonceB64 - Base64-encoded nonce
+     * @param {string} ciphertextB64 - Base64-encoded ciphertext
+     * @returns {Promise<object|null>} Decrypted JSON object, or null on failure
+     */
+    async _e2eDecrypt(nonceB64, ciphertextB64) {
+        try {
+            const nonceBin = atob(nonceB64);
+            const nonce = new Uint8Array(nonceBin.length);
+            for (let i = 0; i < nonceBin.length; i++) nonce[i] = nonceBin.charCodeAt(i);
+
+            const ctBin = atob(ciphertextB64);
+            const ct = new Uint8Array(ctBin.length);
+            for (let i = 0; i < ctBin.length; i++) ct[i] = ctBin.charCodeAt(i);
+
+            const plaintext = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv: nonce },
+                this._e2eSharedKey, ct
+            );
+            return JSON.parse(new TextDecoder().decode(plaintext));
+        } catch (e) {
+            console.warn('[E2E] Decryption failed:', e.message);
+            return null;
+        }
+    }
+
+    /**
+     * Initiate E2E key exchange with a worker. Called from sjEnterStep3() and
+     * sjGoToInferenceStep() after opening the SSE connection.
+     *
+     * Sends our ephemeral public key, waits for the worker's response on SSE,
+     * derives the shared AES key. Retries once on timeout (5s).
+     *
+     * @param {string} peerId - Worker peer ID
+     * @returns {Promise<boolean>} True if key exchange succeeded
+     */
+    async _e2eInitKeyExchange(peerId) {
+        this._e2eReady = false;
+        this._e2eSharedKey = null;
+        this._e2eSessionId = crypto.randomUUID();
+
+        const { privateKey, publicKeyRaw } = await this._e2eGenerateKeypair();
+        this._e2ePrivateKey = privateKey;
+
+        // Encode public key as URL-safe base64 (no padding)
+        const pubBytes = new Uint8Array(publicKeyRaw);
+        let pubB64 = btoa(String.fromCharCode(...pubBytes))
+            .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+        const attempt = async () => {
+            return new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                    reject(new Error('Key exchange timeout'));
+                }, 5000);
+
+                // Listen for key_exchange_response on existing SSE
+                const originalHandler = this._sjWorkerSSE?.raw?.onmessage;
+                const wrappedHandler = async (event) => {
+                    let data;
+                    try { data = JSON.parse(event.data); } catch { return; }
+
+                    if (data.type === 'key_exchange_response' &&
+                        data.session_id === this._e2eSessionId) {
+                        clearTimeout(timeout);
+
+                        // Decode worker's public key
+                        let workerPubB64 = data.public_key
+                            .replace(/-/g, '+').replace(/_/g, '/');
+                        while (workerPubB64.length % 4) workerPubB64 += '=';
+                        const workerPubBin = atob(workerPubB64);
+                        const workerPubBytes = new Uint8Array(workerPubBin.length);
+                        for (let i = 0; i < workerPubBin.length; i++)
+                            workerPubBytes[i] = workerPubBin.charCodeAt(i);
+
+                        // Derive shared key
+                        try {
+                            this._e2eSharedKey = await this._e2eDeriveKey(
+                                this._e2ePrivateKey, workerPubBytes.buffer
+                            );
+                            this._e2eReady = true;
+                            console.log(`[E2E] Key exchange complete (session ${this._e2eSessionId.slice(0, 8)}...)`);
+                            resolve(true);
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+
+                    // Also call original handler for other message types
+                    if (originalHandler) originalHandler(event);
+                };
+
+                // Temporarily wrap the SSE handler to intercept key_exchange_response
+                if (this._sjWorkerSSE?.raw) {
+                    this._sjWorkerSSE.raw.onmessage = wrappedHandler;
+                }
+
+                // Send key exchange request
+                this.apiWorkerMessage(this._sjRoomId, peerId, {
+                    type: 'key_exchange',
+                    session_id: this._e2eSessionId,
+                    public_key: pubB64,
+                }).catch(reject);
+            });
+        };
+
+        // Try twice
+        for (let i = 0; i < 2; i++) {
+            try {
+                await attempt();
+                return true;
+            } catch (e) {
+                console.warn(`[E2E] Key exchange attempt ${i + 1} failed: ${e.message}`);
+                if (i === 0) continue; // Retry once
+            }
+        }
+
+        console.error('[E2E] Key exchange failed after 2 attempts');
+        return false;
+    }
+
     /**
      * Forward an arbitrary message to a worker via the signaling server.
+     * If E2E encryption is active, the message is encrypted before sending.
      */
     async apiWorkerMessage(roomId, peerId, message) {
+        let outMessage = message;
+
+        // Encrypt if E2E is ready (but not the key_exchange itself)
+        if (this._e2eReady && this._e2eSharedKey && message.type !== 'key_exchange') {
+            const { nonce, ciphertext } = await this._e2eEncrypt(message);
+            outMessage = {
+                type: 'encrypted_relay',
+                session_id: this._e2eSessionId,
+                nonce,
+                ciphertext,
+            };
+        }
+
         return this.apiRequest('/api/worker/message', {
             method: 'POST',
-            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message }),
+            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message: outMessage }),
         });
     }
 
     /**
      * Request a directory listing from a worker's filesystem.
+     * When E2E is active, routes through apiWorkerMessage for encryption.
      */
     async apiFsList(roomId, peerId, path, reqId, offset = 0) {
+        if (this._e2eReady && this._e2eSharedKey) {
+            return this.apiWorkerMessage(roomId, peerId, {
+                type: 'fs_list_req', path, req_id: reqId, offset,
+            });
+        }
         return this.apiRequest('/api/fs/list', {
             method: 'POST',
             body: JSON.stringify({ room_id: roomId, peer_id: peerId, path, req_id: reqId, offset }),
@@ -704,8 +941,14 @@ class SleapRTCDashboard {
 
     /**
      * Submit a training job to a worker.
+     * When E2E is active, routes through apiWorkerMessage for encryption.
      */
     async apiJobSubmit(roomId, peerId, config) {
+        if (this._e2eReady && this._e2eSharedKey) {
+            return this.apiWorkerMessage(roomId, peerId, {
+                type: 'job_assigned', config,
+            });
+        }
         return this.apiRequest('/api/jobs/submit', {
             method: 'POST',
             body: JSON.stringify({ room_id: roomId, peer_id: peerId, config }),
@@ -2475,7 +2718,7 @@ class SleapRTCDashboard {
         }
     }
 
-    sjGoToInferenceStep() {
+    async sjGoToInferenceStep() {
         // Hide all views
         ['sj-step1', 'sj-step2', 'sj-step3', 'sj-status'].forEach(id => {
             document.getElementById(id)?.classList.add('hidden');
@@ -2509,6 +2752,17 @@ class SleapRTCDashboard {
             .on('fs_list_res', (data) => this._sjHandleFsListRes(data))
             .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
             .on('worker_path_error', (data) => this._sjHandlePathError(data));
+
+        // E2E key exchange with worker
+        const inferenceError = document.getElementById('sj-inference-error');
+        const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
+        if (!e2eOk) {
+            if (inferenceError) {
+                inferenceError.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
+                inferenceError.classList.remove('hidden');
+            }
+            return;
+        }
 
         // Init icons
         const inferenceView = document.getElementById('sj-step-inference');
@@ -3419,6 +3673,18 @@ class SleapRTCDashboard {
                 .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
                 .on('worker_path_error', (data) => this._sjHandlePathError(data))
                 .on('fs_check_videos_response', (data) => this._sjHandleVideoCheck(data));
+
+            // E2E key exchange with worker
+            const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
+            if (!e2eOk) {
+                document.getElementById('sj-browser-spinner')?.classList.add('hidden');
+                const errEl = document.getElementById('sj-browser-error');
+                if (errEl) {
+                    errEl.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
+                    errEl.classList.remove('hidden');
+                }
+                return;
+            }
 
             // Re-fetch worker data to get fresh metadata (mounts may change after reconnection)
             await this.loadRoomWorkers(this._sjRoomId);

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -147,12 +147,6 @@ class SleapRTCDashboard {
         this.activeJobs = new Map(); // jobId → job state
         this._workerPollInterval = null;
 
-        // E2E encryption state (per-session, cleared on page refresh)
-        this._e2eSessionId = null;
-        this._e2ePrivateKey = null;  // CryptoKey (P-256 ECDH)
-        this._e2eSharedKey = null;   // CryptoKey (AES-256-GCM)
-        this._e2eReady = false;
-
         this.init();
     }
 
@@ -668,25 +662,10 @@ class SleapRTCDashboard {
         const url = `${CONFIG.RELAY_SERVER}/stream/${encodeURIComponent(channel)}`;
         const es = new EventSource(url);
         const handlers = {};
-        const dashboard = this;
 
-        es.onmessage = async (event) => {
+        es.onmessage = (event) => {
             let data;
             try { data = JSON.parse(event.data); } catch { return; }
-
-            // Handle encrypted relay messages — decrypt and re-dispatch
-            if (data.type === 'encrypted_relay') {
-                if (!dashboard._e2eReady || !dashboard._e2eSharedKey) {
-                    return; // No key yet, discard
-                }
-                if (data.session_id !== dashboard._e2eSessionId) {
-                    return; // Stale session, discard
-                }
-                const decrypted = await dashboard._e2eDecrypt(data.nonce, data.ciphertext);
-                if (!decrypted) return; // Decryption failed, discard silently
-                data = decrypted;
-            }
-
             const type = data.type;
             if (type && handlers[type]) handlers[type](data);
             if (handlers['*']) handlers['*'](data);
@@ -703,229 +682,18 @@ class SleapRTCDashboard {
         };
     }
 
-    // =========================================================================
-    // E2E Encryption for Relay Transport
-    // =========================================================================
-
-    /**
-     * Generate an ephemeral ECDH P-256 keypair for E2E encryption.
-     * @returns {Promise<{privateKey: CryptoKey, publicKeyRaw: ArrayBuffer}>}
-     */
-    async _e2eGenerateKeypair() {
-        const keyPair = await crypto.subtle.generateKey(
-            { name: 'ECDH', namedCurve: 'P-256' },
-            false, // private key not extractable
-            ['deriveBits']
-        );
-        const publicKeyRaw = await crypto.subtle.exportKey('raw', keyPair.publicKey);
-        return { privateKey: keyPair.privateKey, publicKeyRaw };
-    }
-
-    /**
-     * Derive an AES-256-GCM key from ECDH shared secret + HKDF.
-     * Parameters must match Python side exactly.
-     * @param {CryptoKey} privateKey - Our P-256 private key
-     * @param {ArrayBuffer} peerPublicKeyRaw - Peer's raw public key (65 bytes)
-     * @returns {Promise<CryptoKey>} AES-256-GCM key
-     */
-    async _e2eDeriveKey(privateKey, peerPublicKeyRaw) {
-        const peerPublicKey = await crypto.subtle.importKey(
-            'raw', peerPublicKeyRaw,
-            { name: 'ECDH', namedCurve: 'P-256' },
-            false, []
-        );
-
-        // ECDH → shared secret
-        const sharedBits = await crypto.subtle.deriveBits(
-            { name: 'ECDH', public: peerPublicKey },
-            privateKey, 256
-        );
-
-        // Import as HKDF key material
-        const hkdfKey = await crypto.subtle.importKey(
-            'raw', sharedBits, 'HKDF', false, ['deriveKey']
-        );
-
-        // HKDF → AES-256-GCM key (must match Python: SHA-256, no salt, info="sleap-rtc-relay-e2e-v1")
-        return crypto.subtle.deriveKey(
-            {
-                name: 'HKDF',
-                hash: 'SHA-256',
-                salt: new Uint8Array(0),
-                info: new TextEncoder().encode('sleap-rtc-relay-e2e-v1'),
-            },
-            hkdfKey,
-            { name: 'AES-GCM', length: 256 },
-            false, ['encrypt', 'decrypt']
-        );
-    }
-
-    /**
-     * Encrypt a JSON payload with AES-256-GCM.
-     * @param {object} payload - JSON-serializable object
-     * @returns {Promise<{nonce: string, ciphertext: string}>} Base64-encoded nonce and ciphertext
-     */
-    async _e2eEncrypt(payload) {
-        const nonce = crypto.getRandomValues(new Uint8Array(12));
-        const plaintext = new TextEncoder().encode(JSON.stringify(payload));
-        const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
-            { name: 'AES-GCM', iv: nonce },
-            this._e2eSharedKey, plaintext
-        ));
-        return {
-            nonce: btoa(String.fromCharCode(...nonce)),
-            ciphertext: btoa(String.fromCharCode(...ciphertext)),
-        };
-    }
-
-    /**
-     * Decrypt an AES-256-GCM ciphertext back to a JSON object.
-     * @param {string} nonceB64 - Base64-encoded nonce
-     * @param {string} ciphertextB64 - Base64-encoded ciphertext
-     * @returns {Promise<object|null>} Decrypted JSON object, or null on failure
-     */
-    async _e2eDecrypt(nonceB64, ciphertextB64) {
-        try {
-            const nonceBin = atob(nonceB64);
-            const nonce = new Uint8Array(nonceBin.length);
-            for (let i = 0; i < nonceBin.length; i++) nonce[i] = nonceBin.charCodeAt(i);
-
-            const ctBin = atob(ciphertextB64);
-            const ct = new Uint8Array(ctBin.length);
-            for (let i = 0; i < ctBin.length; i++) ct[i] = ctBin.charCodeAt(i);
-
-            const plaintext = await crypto.subtle.decrypt(
-                { name: 'AES-GCM', iv: nonce },
-                this._e2eSharedKey, ct
-            );
-            return JSON.parse(new TextDecoder().decode(plaintext));
-        } catch (e) {
-            console.warn('[E2E] Decryption failed:', e.message);
-            return null;
-        }
-    }
-
-    /**
-     * Initiate E2E key exchange with a worker. Called from sjEnterStep3() and
-     * sjGoToInferenceStep() after opening the SSE connection.
-     *
-     * Sends our ephemeral public key, waits for the worker's response on SSE,
-     * derives the shared AES key. Retries once on timeout (5s).
-     *
-     * @param {string} peerId - Worker peer ID
-     * @returns {Promise<boolean>} True if key exchange succeeded
-     */
-    async _e2eInitKeyExchange(peerId) {
-        this._e2eReady = false;
-        this._e2eSharedKey = null;
-        this._e2eSessionId = crypto.randomUUID();
-
-        const { privateKey, publicKeyRaw } = await this._e2eGenerateKeypair();
-        this._e2ePrivateKey = privateKey;
-
-        // Encode public key as URL-safe base64 (no padding)
-        const pubBytes = new Uint8Array(publicKeyRaw);
-        let pubB64 = btoa(String.fromCharCode(...pubBytes))
-            .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-
-        const attempt = async () => {
-            return new Promise((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                    reject(new Error('Key exchange timeout'));
-                }, 5000);
-
-                // Listen for key_exchange_response on existing SSE
-                const originalHandler = this._sjWorkerSSE?.raw?.onmessage;
-                const wrappedHandler = async (event) => {
-                    let data;
-                    try { data = JSON.parse(event.data); } catch { return; }
-
-                    if (data.type === 'key_exchange_response' &&
-                        data.session_id === this._e2eSessionId) {
-                        clearTimeout(timeout);
-
-                        // Decode worker's public key
-                        let workerPubB64 = data.public_key
-                            .replace(/-/g, '+').replace(/_/g, '/');
-                        while (workerPubB64.length % 4) workerPubB64 += '=';
-                        const workerPubBin = atob(workerPubB64);
-                        const workerPubBytes = new Uint8Array(workerPubBin.length);
-                        for (let i = 0; i < workerPubBin.length; i++)
-                            workerPubBytes[i] = workerPubBin.charCodeAt(i);
-
-                        // Derive shared key
-                        try {
-                            this._e2eSharedKey = await this._e2eDeriveKey(
-                                this._e2ePrivateKey, workerPubBytes.buffer
-                            );
-                            this._e2eReady = true;
-                            console.log(`[E2E] Key exchange complete (session ${this._e2eSessionId.slice(0, 8)}...)`);
-                            resolve(true);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-
-                    // Also call original handler for other message types
-                    if (originalHandler) originalHandler(event);
-                };
-
-                // Temporarily wrap the SSE handler to intercept key_exchange_response
-                if (this._sjWorkerSSE?.raw) {
-                    this._sjWorkerSSE.raw.onmessage = wrappedHandler;
-                }
-
-                // Send key exchange request
-                this.apiWorkerMessage(this._sjRoomId, peerId, {
-                    type: 'key_exchange',
-                    session_id: this._e2eSessionId,
-                    public_key: pubB64,
-                }).catch(reject);
-            });
-        };
-
-        // Try twice
-        for (let i = 0; i < 2; i++) {
-            try {
-                await attempt();
-                return true;
-            } catch (e) {
-                console.warn(`[E2E] Key exchange attempt ${i + 1} failed: ${e.message}`);
-                if (i === 0) continue; // Retry once
-            }
-        }
-
-        console.error('[E2E] Key exchange failed after 2 attempts');
-        return false;
-    }
-
     /**
      * Forward an arbitrary message to a worker via the signaling server.
-     * If E2E encryption is active, the message is encrypted before sending.
      */
     async apiWorkerMessage(roomId, peerId, message) {
-        let outMessage = message;
-
-        // Encrypt if E2E is ready (but not the key_exchange itself)
-        if (this._e2eReady && this._e2eSharedKey && message.type !== 'key_exchange') {
-            const { nonce, ciphertext } = await this._e2eEncrypt(message);
-            outMessage = {
-                type: 'encrypted_relay',
-                session_id: this._e2eSessionId,
-                nonce,
-                ciphertext,
-            };
-        }
-
         return this.apiRequest('/api/worker/message', {
             method: 'POST',
-            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message: outMessage }),
+            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message }),
         });
     }
 
     /**
      * Request a directory listing from a worker's filesystem.
-     * When E2E is active, routes through apiWorkerMessage for encryption.
      */
     async apiFsList(roomId, peerId, path, reqId, offset = 0) {
         if (this._e2eReady && this._e2eSharedKey) {
@@ -941,13 +709,17 @@ class SleapRTCDashboard {
 
     /**
      * Submit a training job to a worker.
-     * When E2E is active, routes through apiWorkerMessage for encryption.
+     * When E2E is active, generates job_id client-side and routes through
+     * apiWorkerMessage. The dedicated endpoint can't be used because the
+     * signaling server would see the config in plaintext.
      */
     async apiJobSubmit(roomId, peerId, config) {
         if (this._e2eReady && this._e2eSharedKey) {
-            return this.apiWorkerMessage(roomId, peerId, {
-                type: 'job_assigned', config,
+            const jobId = `job_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+            await this.apiWorkerMessage(roomId, peerId, {
+                type: 'job_assigned', job_id: jobId, config,
             });
+            return { job_id: jobId };
         }
         return this.apiRequest('/api/jobs/submit', {
             method: 'POST',
@@ -2718,7 +2490,7 @@ class SleapRTCDashboard {
         }
     }
 
-    async sjGoToInferenceStep() {
+    sjGoToInferenceStep() {
         // Hide all views
         ['sj-step1', 'sj-step2', 'sj-step3', 'sj-status'].forEach(id => {
             document.getElementById(id)?.classList.add('hidden');
@@ -2752,17 +2524,6 @@ class SleapRTCDashboard {
             .on('fs_list_res', (data) => this._sjHandleFsListRes(data))
             .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
             .on('worker_path_error', (data) => this._sjHandlePathError(data));
-
-        // E2E key exchange with worker
-        const inferenceError = document.getElementById('sj-inference-error');
-        const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
-        if (!e2eOk) {
-            if (inferenceError) {
-                inferenceError.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
-                inferenceError.classList.remove('hidden');
-            }
-            return;
-        }
 
         // Init icons
         const inferenceView = document.getElementById('sj-step-inference');
@@ -3673,18 +3434,6 @@ class SleapRTCDashboard {
                 .on('worker_path_ok', (data) => this._sjHandlePathOk(data))
                 .on('worker_path_error', (data) => this._sjHandlePathError(data))
                 .on('fs_check_videos_response', (data) => this._sjHandleVideoCheck(data));
-
-            // E2E key exchange with worker
-            const e2eOk = await this._e2eInitKeyExchange(this._sjWorkerId);
-            if (!e2eOk) {
-                document.getElementById('sj-browser-spinner')?.classList.add('hidden');
-                const errEl = document.getElementById('sj-browser-error');
-                if (errEl) {
-                    errEl.textContent = 'Could not establish secure connection with worker. The worker may need to be updated.';
-                    errEl.classList.remove('hidden');
-                }
-                return;
-            }
 
             // Re-fetch worker data to get fresh metadata (mounts may change after reconnection)
             await this.loadRoomWorkers(this._sjRoomId);

--- a/sleap_rtc/encryption/__init__.py
+++ b/sleap_rtc/encryption/__init__.py
@@ -1,0 +1,28 @@
+"""E2E encryption for the relay transport path.
+
+Provides ECDH P-256 key exchange and AES-256-GCM message encryption so that
+relay messages between dashboard/sleap-app clients and workers are encrypted
+end-to-end. The signaling server can route messages but cannot read payloads.
+"""
+
+from sleap_rtc.encryption.ecdh import (
+    decrypt,
+    derive_shared_key,
+    encrypt,
+    generate_keypair,
+    public_key_from_b64,
+    public_key_to_b64,
+)
+from sleap_rtc.encryption.envelope import ENCRYPTED_RELAY_TYPE, unwrap, wrap
+
+__all__ = [
+    "ENCRYPTED_RELAY_TYPE",
+    "decrypt",
+    "derive_shared_key",
+    "encrypt",
+    "generate_keypair",
+    "public_key_from_b64",
+    "public_key_to_b64",
+    "unwrap",
+    "wrap",
+]

--- a/sleap_rtc/encryption/ecdh.py
+++ b/sleap_rtc/encryption/ecdh.py
@@ -1,0 +1,144 @@
+"""ECDH P-256 key exchange and AES-256-GCM encryption for relay E2E encryption.
+
+This module provides key generation, Diffie-Hellman key derivation, and
+authenticated encryption for the relay transport path. The P2P data channel
+path uses DTLS (built into WebRTC) instead.
+
+Protocol:
+1. Client sends key_exchange with ephemeral P-256 public key
+2. Worker generates ephemeral P-256 keypair, derives shared AES key via ECDH+HKDF
+3. Worker sends key_exchange_response with its public key
+4. Client derives same AES key
+5. All subsequent relay messages encrypted with AES-256-GCM
+
+Parameters (must match JavaScript Web Crypto API side):
+- Curve: P-256 (secp256r1)
+- KDF: HKDF-SHA256, no salt, info=b"sleap-rtc-relay-e2e-v1"
+- Cipher: AES-256-GCM, 12-byte nonce
+"""
+
+import base64
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes, serialization
+
+# HKDF info string — must match the JavaScript side exactly.
+HKDF_INFO = b"sleap-rtc-relay-e2e-v1"
+
+# AES-GCM nonce size in bytes (96-bit).
+NONCE_SIZE = 12
+
+
+def generate_keypair() -> tuple[ec.EllipticCurvePrivateKey, bytes]:
+    """Generate an ephemeral P-256 keypair for ECDH key exchange.
+
+    Returns:
+        Tuple of (private_key, public_key_bytes) where public_key_bytes is the
+        uncompressed point encoding (65 bytes: 0x04 || x || y).
+    """
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_key_bytes = private_key.public_key().public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+    return private_key, public_key_bytes
+
+
+def public_key_to_b64(public_key_bytes: bytes) -> str:
+    """Encode a public key as URL-safe base64 (no padding).
+
+    Args:
+        public_key_bytes: Uncompressed P-256 point (65 bytes).
+
+    Returns:
+        URL-safe base64 string without padding.
+    """
+    return base64.urlsafe_b64encode(public_key_bytes).rstrip(b"=").decode()
+
+
+def public_key_from_b64(b64: str) -> bytes:
+    """Decode a public key from URL-safe base64 (no padding).
+
+    Args:
+        b64: URL-safe base64-encoded public key.
+
+    Returns:
+        Raw public key bytes (65 bytes uncompressed point).
+    """
+    padding = 4 - (len(b64) % 4)
+    if padding != 4:
+        b64 += "=" * padding
+    return base64.urlsafe_b64decode(b64)
+
+
+def derive_shared_key(
+    private_key: ec.EllipticCurvePrivateKey,
+    peer_public_key_bytes: bytes,
+) -> bytes:
+    """Derive a 256-bit AES key from ECDH shared secret + HKDF.
+
+    Both sides must call this with the other's public key to arrive at the
+    same derived key.
+
+    Args:
+        private_key: Our P-256 private key.
+        peer_public_key_bytes: Peer's public key (uncompressed point, 65 bytes).
+
+    Returns:
+        32-byte AES-256 key.
+    """
+    peer_public_key = ec.EllipticCurvePublicKey.from_encoded_point(
+        ec.SECP256R1(), peer_public_key_bytes
+    )
+    shared_secret = private_key.exchange(ec.ECDH(), peer_public_key)
+
+    derived_key = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=HKDF_INFO,
+    ).derive(shared_secret)
+
+    return derived_key
+
+
+def encrypt(key: bytes, plaintext: dict) -> tuple[bytes, bytes]:
+    """Encrypt a JSON-serializable dict with AES-256-GCM.
+
+    Args:
+        key: 32-byte AES key from derive_shared_key().
+        plaintext: Dict to encrypt (will be JSON-serialized).
+
+    Returns:
+        Tuple of (nonce, ciphertext) as raw bytes. The ciphertext includes
+        the 16-byte GCM authentication tag appended.
+    """
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(NONCE_SIZE)
+    plaintext_bytes = json.dumps(plaintext, separators=(",", ":")).encode("utf-8")
+    ciphertext = aesgcm.encrypt(nonce, plaintext_bytes, None)
+    return nonce, ciphertext
+
+
+def decrypt(key: bytes, nonce: bytes, ciphertext: bytes) -> dict:
+    """Decrypt an AES-256-GCM ciphertext back to a dict.
+
+    Args:
+        key: 32-byte AES key from derive_shared_key().
+        nonce: 12-byte nonce used during encryption.
+        ciphertext: Ciphertext with appended GCM auth tag.
+
+    Returns:
+        Decrypted JSON dict.
+
+    Raises:
+        cryptography.exceptions.InvalidTag: If decryption fails (wrong key,
+            tampered ciphertext, or wrong nonce).
+    """
+    aesgcm = AESGCM(key)
+    plaintext_bytes = aesgcm.decrypt(nonce, ciphertext, None)
+    return json.loads(plaintext_bytes.decode("utf-8"))

--- a/sleap_rtc/encryption/envelope.py
+++ b/sleap_rtc/encryption/envelope.py
@@ -1,0 +1,105 @@
+"""Encrypted relay message envelope for E2E encryption.
+
+Wraps and unwraps relay messages into encrypted envelopes that preserve
+plaintext routing fields (type, session_id, job_id, req_id) while encrypting
+the actual message payload.
+
+Envelope format (what the signaling server sees):
+{
+    "type": "encrypted_relay",
+    "session_id": "<uuid>",
+    "job_id": "<optional, for relay channel routing>",
+    "req_id": "<optional, for request matching>",
+    "nonce": "<base64, 12 bytes>",
+    "ciphertext": "<base64, AES-GCM encrypted payload>"
+}
+
+The signaling server can route based on the plaintext fields but cannot
+read the encrypted payload.
+"""
+
+import base64
+import logging
+
+from cryptography.exceptions import InvalidTag
+
+from sleap_rtc.encryption.ecdh import decrypt, encrypt
+
+logger = logging.getLogger(__name__)
+
+# Message type used for encrypted relay envelopes.
+ENCRYPTED_RELAY_TYPE = "encrypted_relay"
+
+
+def wrap(
+    key: bytes,
+    session_id: str,
+    message: dict,
+    job_id: str | None = None,
+    req_id: str | None = None,
+) -> dict:
+    """Encrypt a message and wrap it in a relay-compatible envelope.
+
+    Args:
+        key: 32-byte AES key from ECDH key exchange.
+        session_id: Session identifier for key lookup on the receiving side.
+        message: The message dict to encrypt.
+        job_id: Optional job ID for relay channel routing (stays plaintext).
+        req_id: Optional request ID for request/response matching (stays plaintext).
+
+    Returns:
+        Encrypted envelope dict with plaintext routing fields.
+    """
+    nonce, ciphertext = encrypt(key, message)
+
+    envelope = {
+        "type": ENCRYPTED_RELAY_TYPE,
+        "session_id": session_id,
+        "nonce": base64.b64encode(nonce).decode(),
+        "ciphertext": base64.b64encode(ciphertext).decode(),
+    }
+    if job_id is not None:
+        envelope["job_id"] = job_id
+    if req_id is not None:
+        envelope["req_id"] = req_id
+    return envelope
+
+
+def unwrap(
+    envelope: dict,
+    key_lookup: dict[str, bytes],
+) -> dict | None:
+    """Decrypt an encrypted relay envelope back to the original message.
+
+    Args:
+        envelope: Encrypted envelope dict (must have type="encrypted_relay").
+        key_lookup: Dict mapping session_id → AES key.
+
+    Returns:
+        Decrypted message dict, or None if decryption failed (unknown session,
+        wrong key, or tampered message). Failures are logged but not raised.
+    """
+    session_id = envelope.get("session_id")
+    if not session_id:
+        logger.warning("Encrypted relay message missing session_id, discarding")
+        return None
+
+    key = key_lookup.get(session_id)
+    if key is None:
+        logger.debug("Unknown session_id %s, discarding encrypted message", session_id)
+        return None
+
+    try:
+        nonce = base64.b64decode(envelope["nonce"])
+        ciphertext = base64.b64decode(envelope["ciphertext"])
+    except (KeyError, Exception) as e:
+        logger.warning("Malformed encrypted envelope: %s", e)
+        return None
+
+    try:
+        return decrypt(key, nonce, ciphertext)
+    except InvalidTag:
+        logger.warning(
+            "Decryption failed for session %s (invalid tag), discarding", session_id
+        )
+        return None

--- a/sleap_rtc/worker/mesh_coordinator.py
+++ b/sleap_rtc/worker/mesh_coordinator.py
@@ -108,6 +108,11 @@ class MeshCoordinator:
         # Non-admin WebSocket handler task (for post-demotion signaling)
         self._non_admin_handler_task: Optional[asyncio.Task] = None
 
+        # E2E encryption sessions: {session_id: (aes_key, timestamp)}
+        self._e2e_sessions: Dict[str, tuple[bytes, float]] = {}
+        # Max age for session keys (seconds) before pruning
+        self._e2e_session_max_age: float = 86400  # 24 hours
+
     def _build_registration_msg(self, is_admin: bool) -> dict:
         """Build a registration message with full worker metadata.
 
@@ -326,6 +331,38 @@ class MeshCoordinator:
                     elif msg_type == "error":
                         logger.error(f"Admin received error: {data.get('reason')}")
 
+                    # ── E2E encryption ─────────────────────────────────
+                    elif msg_type == "key_exchange":
+                        await self._handle_key_exchange(data)
+
+                    elif msg_type == "encrypted_relay":
+                        decrypted, session_id = self._decrypt_if_encrypted(data)
+                        if decrypted is not None:
+                            # Re-dispatch the decrypted inner message
+                            inner_type = decrypted.get("type")
+                            if inner_type == "fs_list_req":
+                                await self._handle_fs_list_req(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "use_worker_path":
+                                await self._handle_use_worker_path(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "fs_check_videos":
+                                await self._handle_fs_check_videos(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "job_assigned":
+                                await self._handle_job_assigned(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "job_cancel":
+                                self._handle_job_cancel(decrypted)
+                            else:
+                                logger.debug(
+                                    f"[E2E] Unknown decrypted type: {inner_type}"
+                                )
+
                     # ── Relay-forwarded requests from dashboard ──────────
                     elif msg_type == "fs_list_req":
                         await self._handle_fs_list_req(data)
@@ -365,7 +402,9 @@ class MeshCoordinator:
 
     # ── Relay-forwarded request handlers ────────────────────────────────────
 
-    async def _handle_fs_list_req(self, data: Dict[str, Any]):
+    async def _handle_fs_list_req(
+        self, data: Dict[str, Any], session_id: str | None = None
+    ):
         """Handle fs_list_req forwarded from dashboard via signaling server.
 
         Translates to the worker's FS_LIST_DIR protocol, sends back fs_list_res
@@ -389,31 +428,27 @@ class MeshCoordinator:
         if response.startswith(f"{MSG_FS_LIST_RESPONSE}{MSG_SEPARATOR}"):
             json_str = response.split(MSG_SEPARATOR, 1)[1]
             result = json.loads(json_str)
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "fs_list_res",
-                        "req_id": req_id,
-                        **result,
-                    }
-                )
+            await self._send_relay_response(
+                {"type": "fs_list_res", "req_id": req_id, **result},
+                session_id=session_id,
             )
             logger.info(f"[RELAY] Sent fs_list_res for path={path}")
         else:
             # Error response
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "fs_list_res",
-                        "req_id": req_id,
-                        "error": response,
-                        "entries": [],
-                    }
-                )
+            await self._send_relay_response(
+                {
+                    "type": "fs_list_res",
+                    "req_id": req_id,
+                    "error": response,
+                    "entries": [],
+                },
+                session_id=session_id,
             )
             logger.warning(f"[RELAY] FS list error for path={path}: {response}")
 
-    async def _handle_use_worker_path(self, data: Dict[str, Any]):
+    async def _handle_use_worker_path(
+        self, data: Dict[str, Any], session_id: str | None = None
+    ):
         """Handle use_worker_path forwarded from dashboard via signaling server.
 
         Validates the path, then checks video accessibility if it's an SLP file.
@@ -433,13 +468,9 @@ class MeshCoordinator:
 
         if response.startswith(f"{MSG_WORKER_PATH_OK}{MSG_SEPARATOR}"):
             validated_path = response.split(MSG_SEPARATOR, 1)[1]
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "worker_path_ok",
-                        "path": validated_path,
-                    }
-                )
+            await self._send_relay_response(
+                {"type": "worker_path_ok", "path": validated_path},
+                session_id=session_id,
             )
             logger.info(f"[RELAY] Sent worker_path_ok for {validated_path}")
 
@@ -448,13 +479,9 @@ class MeshCoordinator:
             if video_response:
                 json_str = video_response.split(MSG_SEPARATOR, 1)[1]
                 result = json.loads(json_str)
-                await self.websocket.send(
-                    json.dumps(
-                        {
-                            "type": "fs_check_videos_response",
-                            **result,
-                        }
-                    )
+                await self._send_relay_response(
+                    {"type": "fs_check_videos_response", **result},
+                    session_id=session_id,
                 )
                 logger.info(f"[RELAY] Sent fs_check_videos_response")
         else:
@@ -463,17 +490,15 @@ class MeshCoordinator:
                 if MSG_SEPARATOR in response
                 else response
             )
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "worker_path_error",
-                        "error": error_msg,
-                    }
-                )
+            await self._send_relay_response(
+                {"type": "worker_path_error", "error": error_msg},
+                session_id=session_id,
             )
             logger.warning(f"[RELAY] Sent worker_path_error: {error_msg}")
 
-    async def _handle_fs_check_videos(self, data: Dict[str, Any]):
+    async def _handle_fs_check_videos(
+        self, data: Dict[str, Any], session_id: str | None = None
+    ):
         """Handle explicit fs_check_videos request from dashboard."""
         from sleap_rtc.protocol import MSG_FS_CHECK_VIDEOS_RESPONSE, MSG_SEPARATOR
 
@@ -481,28 +506,25 @@ class MeshCoordinator:
         if response:
             json_str = response.split(MSG_SEPARATOR, 1)[1]
             result = json.loads(json_str)
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "fs_check_videos_response",
-                        **result,
-                    }
-                )
+            await self._send_relay_response(
+                {"type": "fs_check_videos_response", **result},
+                session_id=session_id,
             )
             logger.info(f"[RELAY] Sent fs_check_videos_response")
         else:
-            await self.websocket.send(
-                json.dumps(
-                    {
-                        "type": "fs_check_videos_response",
-                        "missing": [],
-                        "accessible": 0,
-                        "embedded": 0,
-                    }
-                )
+            await self._send_relay_response(
+                {
+                    "type": "fs_check_videos_response",
+                    "missing": [],
+                    "accessible": 0,
+                    "embedded": 0,
+                },
+                session_id=session_id,
             )
 
-    async def _handle_job_assigned(self, data: Dict[str, Any]):
+    async def _handle_job_assigned(
+        self, data: Dict[str, Any], session_id: str | None = None
+    ):
         """Handle job_assigned forwarded from dashboard via signaling server.
 
         Translates to the worker's existing handle_job_submit flow, using a
@@ -521,6 +543,7 @@ class MeshCoordinator:
         # WebSocket sends on the event loop.
         coordinator = self  # Reference to mesh coordinator for dynamic websocket access
         loop = asyncio.get_event_loop()
+        e2e_session_id = session_id  # Capture for RelayChannel closure
 
         class RelayChannel:
             """Shim that mimics RTCDataChannel.send() but routes through WebSocket."""
@@ -676,6 +699,25 @@ class MeshCoordinator:
                 # (end of message routing)
 
                 if relay_msg:
+                    # Encrypt if E2E session is active
+                    if e2e_session_id is not None:
+                        e2e_key = self._coordinator._get_e2e_key_for_session(
+                            e2e_session_id
+                        )
+                        if e2e_key is not None:
+                            from sleap_rtc.encryption.envelope import wrap as _wrap
+
+                            envelope = _wrap(
+                                e2e_key,
+                                e2e_session_id,
+                                relay_msg,
+                                job_id=self._job_id,
+                            )
+                            asyncio.run_coroutine_threadsafe(
+                                self._coordinator.websocket.send(_j.dumps(envelope)),
+                                loop,
+                            )
+                            return
                     asyncio.run_coroutine_threadsafe(
                         self._coordinator.websocket.send(_j.dumps(relay_msg)), loop
                     )
@@ -749,6 +791,131 @@ class MeshCoordinator:
             logger.info(
                 f"[RELAY] SIGTERM cancel sent for job {job_id} (no ZMQ reporter)"
             )
+
+    # ── E2E encryption for relay transport ───────────────────────────────
+
+    async def _handle_key_exchange(self, data: Dict[str, Any]):
+        """Handle key_exchange from a dashboard/relay client.
+
+        Generates an ephemeral P-256 keypair, derives the shared AES key via
+        ECDH + HKDF, stores it keyed by session_id, and sends the worker's
+        public key back via key_exchange_response.
+        """
+        from sleap_rtc.encryption import (
+            generate_keypair,
+            derive_shared_key,
+            public_key_from_b64,
+            public_key_to_b64,
+        )
+
+        session_id = data.get("session_id")
+        peer_pub_b64 = data.get("public_key")
+
+        if not session_id or not peer_pub_b64:
+            logger.warning("[E2E] key_exchange missing session_id or public_key")
+            return
+
+        try:
+            # Generate our ephemeral keypair
+            private_key, our_pub_bytes = generate_keypair()
+
+            # Derive shared AES-256 key
+            peer_pub_bytes = public_key_from_b64(peer_pub_b64)
+            shared_key = derive_shared_key(private_key, peer_pub_bytes)
+
+            # Prune old sessions before adding new one
+            self._prune_e2e_sessions()
+
+            # Store session key
+            self._e2e_sessions[session_id] = (shared_key, time.time())
+            logger.info(
+                f"[E2E] Key exchange complete for session {session_id[:8]}... "
+                f"({len(self._e2e_sessions)} active sessions)"
+            )
+
+            # Send our public key back
+            response = {
+                "type": "key_exchange_response",
+                "session_id": session_id,
+                "public_key": public_key_to_b64(our_pub_bytes),
+            }
+            await self.websocket.send(json.dumps(response))
+
+        except Exception as e:
+            logger.error(f"[E2E] Key exchange failed: {e}")
+
+    def _prune_e2e_sessions(self):
+        """Remove E2E sessions older than max age."""
+        now = time.time()
+        expired = [
+            sid
+            for sid, (_, ts) in self._e2e_sessions.items()
+            if now - ts > self._e2e_session_max_age
+        ]
+        for sid in expired:
+            del self._e2e_sessions[sid]
+            logger.debug(f"[E2E] Pruned expired session {sid[:8]}...")
+
+    def _decrypt_if_encrypted(self, data: Dict[str, Any]) -> tuple[Dict[str, Any], str | None]:
+        """If the message is an encrypted relay envelope, decrypt it.
+
+        Args:
+            data: Incoming message dict.
+
+        Returns:
+            Tuple of (decrypted_data, session_id). If not encrypted, returns
+            (data, None) unchanged. If decryption fails, returns (None, None).
+        """
+        from sleap_rtc.encryption.envelope import ENCRYPTED_RELAY_TYPE, unwrap
+
+        if data.get("type") != ENCRYPTED_RELAY_TYPE:
+            return data, None
+
+        session_id = data.get("session_id")
+        # Build key lookup from sessions dict (strip timestamps)
+        key_lookup = {sid: key for sid, (key, _) in self._e2e_sessions.items()}
+        decrypted = unwrap(data, key_lookup)
+
+        if decrypted is None:
+            logger.warning(
+                f"[E2E] Failed to decrypt message for session "
+                f"{session_id[:8] if session_id else 'unknown'}..."
+            )
+            return None, None
+
+        logger.debug(
+            f"[E2E] Decrypted {decrypted.get('type')} from session {session_id[:8]}..."
+        )
+        return decrypted, session_id
+
+    def _get_e2e_key_for_session(self, session_id: str | None) -> bytes | None:
+        """Get the AES key for a session, or None if not encrypted."""
+        if session_id is None:
+            return None
+        entry = self._e2e_sessions.get(session_id)
+        return entry[0] if entry else None
+
+    async def _send_relay_response(
+        self,
+        message: dict,
+        session_id: str | None = None,
+        job_id: str | None = None,
+    ):
+        """Send a relay response, encrypting if the request was encrypted.
+
+        Args:
+            message: The response message dict to send.
+            session_id: Session ID from the incoming request (None = plaintext).
+            job_id: Optional job_id for relay channel routing.
+        """
+        key = self._get_e2e_key_for_session(session_id)
+        if key is not None:
+            from sleap_rtc.encryption.envelope import wrap
+
+            envelope = wrap(key, session_id, message, job_id=job_id)
+            await self.websocket.send(json.dumps(envelope))
+        else:
+            await self.websocket.send(json.dumps(message))
 
     async def _handle_client_offer(self, data: Dict[str, Any]):
         """Handle client connection offer received on admin WebSocket.
@@ -1977,6 +2144,37 @@ class MeshCoordinator:
 
                     elif msg_type == "error":
                         logger.error(f"Non-admin received error: {data.get('reason')}")
+
+                    # ── E2E encryption ─────────────────────────────────
+                    elif msg_type == "key_exchange":
+                        await self._handle_key_exchange(data)
+
+                    elif msg_type == "encrypted_relay":
+                        decrypted, session_id = self._decrypt_if_encrypted(data)
+                        if decrypted is not None:
+                            inner_type = decrypted.get("type")
+                            if inner_type == "fs_list_req":
+                                await self._handle_fs_list_req(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "use_worker_path":
+                                await self._handle_use_worker_path(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "fs_check_videos":
+                                await self._handle_fs_check_videos(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "job_assigned":
+                                await self._handle_job_assigned(
+                                    decrypted, session_id=session_id
+                                )
+                            elif inner_type == "job_cancel":
+                                self._handle_job_cancel(decrypted)
+                            else:
+                                logger.debug(
+                                    f"[E2E] Unknown decrypted type: {inner_type}"
+                                )
 
                     # ── Relay-forwarded requests from dashboard ──────────
                     elif msg_type == "fs_list_req":

--- a/sleap_rtc/worker/mesh_coordinator.py
+++ b/sleap_rtc/worker/mesh_coordinator.py
@@ -857,7 +857,9 @@ class MeshCoordinator:
             del self._e2e_sessions[sid]
             logger.debug(f"[E2E] Pruned expired session {sid[:8]}...")
 
-    def _decrypt_if_encrypted(self, data: Dict[str, Any]) -> tuple[Dict[str, Any], str | None]:
+    def _decrypt_if_encrypted(
+        self, data: Dict[str, Any]
+    ) -> tuple[Dict[str, Any], str | None]:
         """If the message is an encrypted relay envelope, decrypt it.
 
         Returns:

--- a/sleap_rtc/worker/mesh_coordinator.py
+++ b/sleap_rtc/worker/mesh_coordinator.py
@@ -338,7 +338,6 @@ class MeshCoordinator:
                     elif msg_type == "encrypted_relay":
                         decrypted, session_id = self._decrypt_if_encrypted(data)
                         if decrypted is not None:
-                            # Re-dispatch the decrypted inner message
                             inner_type = decrypted.get("type")
                             if inner_type == "fs_list_req":
                                 await self._handle_fs_list_req(
@@ -816,24 +815,17 @@ class MeshCoordinator:
             return
 
         try:
-            # Generate our ephemeral keypair
             private_key, our_pub_bytes = generate_keypair()
-
-            # Derive shared AES-256 key
             peer_pub_bytes = public_key_from_b64(peer_pub_b64)
             shared_key = derive_shared_key(private_key, peer_pub_bytes)
 
-            # Prune old sessions before adding new one
             self._prune_e2e_sessions()
-
-            # Store session key
             self._e2e_sessions[session_id] = (shared_key, time.time())
             logger.info(
                 f"[E2E] Key exchange complete for session {session_id[:8]}... "
                 f"({len(self._e2e_sessions)} active sessions)"
             )
 
-            # Send our public key back
             response = {
                 "type": "key_exchange_response",
                 "session_id": session_id,
@@ -859,12 +851,9 @@ class MeshCoordinator:
     def _decrypt_if_encrypted(self, data: Dict[str, Any]) -> tuple[Dict[str, Any], str | None]:
         """If the message is an encrypted relay envelope, decrypt it.
 
-        Args:
-            data: Incoming message dict.
-
         Returns:
             Tuple of (decrypted_data, session_id). If not encrypted, returns
-            (data, None) unchanged. If decryption fails, returns (None, None).
+            (data, None). If decryption fails, returns (None, None).
         """
         from sleap_rtc.encryption.envelope import ENCRYPTED_RELAY_TYPE, unwrap
 
@@ -872,7 +861,6 @@ class MeshCoordinator:
             return data, None
 
         session_id = data.get("session_id")
-        # Build key lookup from sessions dict (strip timestamps)
         key_lookup = {sid: key for sid, (key, _) in self._e2e_sessions.items()}
         decrypted = unwrap(data, key_lookup)
 
@@ -901,13 +889,7 @@ class MeshCoordinator:
         session_id: str | None = None,
         job_id: str | None = None,
     ):
-        """Send a relay response, encrypting if the request was encrypted.
-
-        Args:
-            message: The response message dict to send.
-            session_id: Session ID from the incoming request (None = plaintext).
-            job_id: Optional job_id for relay channel routing.
-        """
+        """Send a relay response, encrypting if the request was encrypted."""
         key = self._get_e2e_key_for_session(session_id)
         if key is not None:
             from sleap_rtc.encryption.envelope import wrap

--- a/sleap_rtc/worker/mesh_coordinator.py
+++ b/sleap_rtc/worker/mesh_coordinator.py
@@ -669,23 +669,28 @@ class MeshCoordinator:
                     except Exception:
                         pass  # Silently drop malformed progress reports
                 elif message.startswith("[stderr] "):
-                    # Forward stderr log lines (inference progress, warnings)
-                    line = message[len("[stderr] ") :].rstrip()
-                    if line:
-                        relay_msg = {
-                            **_base,
-                            "status": "running",
-                            "message": line,
-                        }
+                    # Forward stderr log lines — only for inference/track jobs.
+                    # Training uses PROGRESS_REPORT:: for structured updates;
+                    # stderr during training is Lightning's tqdm bar which floods.
+                    if job_type == "track":
+                        line = message[len("[stderr] ") :].rstrip()
+                        if line:
+                            relay_msg = {
+                                **_base,
+                                "status": "running",
+                                "message": line,
+                            }
                 elif message.startswith("CR::"):
-                    # tqdm/rich progress bar update — forward for live display
-                    line = message[4:].strip()
-                    if line:
-                        relay_msg = {
-                            **_base,
-                            "status": "running",
-                            "message": line,
-                        }
+                    # tqdm/rich progress bar update — only for inference/track.
+                    # Training progress bars would flood the relay.
+                    if job_type == "track":
+                        line = message[4:].strip()
+                        if line:
+                            relay_msg = {
+                                **_base,
+                                "status": "running",
+                                "message": line,
+                            }
                 else:
                     # Catch-all for unrecognised text lines. Only forward for
                     # inference/track jobs where stdout is the primary output.

--- a/sleap_rtc/worker/mesh_coordinator.py
+++ b/sleap_rtc/worker/mesh_coordinator.py
@@ -544,6 +544,8 @@ class MeshCoordinator:
         loop = asyncio.get_event_loop()
         e2e_session_id = session_id  # Capture for RelayChannel closure
 
+        job_type = config.get("type", "train")  # "train" or "track"
+
         class RelayChannel:
             """Shim that mimics RTCDataChannel.send() but routes through WebSocket."""
 
@@ -685,16 +687,18 @@ class MeshCoordinator:
                             "message": line,
                         }
                 else:
-                    # Catch-all for unrecognised text lines (e.g., inference
-                    # stdout output). Forward as running status with message
-                    # so they appear in the dashboard worker logs.
-                    line = message.rstrip("\n").strip()
-                    if line and not line.startswith("PROGRESS_REPORT::"):
-                        relay_msg = {
-                            **_base,
-                            "status": "running",
-                            "message": line,
-                        }
+                    # Catch-all for unrecognised text lines. Only forward for
+                    # inference/track jobs where stdout is the primary output.
+                    # Training jobs use PROGRESS_REPORT:: for epoch-level updates
+                    # and would flood the relay with config dumps, model arch, etc.
+                    if job_type == "track":
+                        line = message.rstrip("\n").strip()
+                        if line and not line.startswith("PROGRESS_REPORT::"):
+                            relay_msg = {
+                                **_base,
+                                "status": "running",
+                                "message": line,
+                            }
                 # (end of message routing)
 
                 if relay_msg:

--- a/tests/encryption/test_ecdh.py
+++ b/tests/encryption/test_ecdh.py
@@ -1,0 +1,192 @@
+"""Tests for ECDH P-256 key exchange and AES-256-GCM encryption."""
+
+import json
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from sleap_rtc.encryption.ecdh import (
+    decrypt,
+    derive_shared_key,
+    encrypt,
+    generate_keypair,
+    public_key_from_b64,
+    public_key_to_b64,
+)
+
+
+class TestKeypairGeneration:
+    def test_generate_keypair_returns_private_key_and_bytes(self):
+        private_key, public_key_bytes = generate_keypair()
+        assert private_key is not None
+        assert isinstance(public_key_bytes, bytes)
+
+    def test_public_key_is_65_bytes_uncompressed(self):
+        _, public_key_bytes = generate_keypair()
+        assert len(public_key_bytes) == 65
+        assert public_key_bytes[0] == 0x04  # uncompressed point marker
+
+    def test_each_keypair_is_unique(self):
+        _, pub1 = generate_keypair()
+        _, pub2 = generate_keypair()
+        assert pub1 != pub2
+
+
+class TestPublicKeySerialization:
+    def test_roundtrip(self):
+        _, public_key_bytes = generate_keypair()
+        b64 = public_key_to_b64(public_key_bytes)
+        restored = public_key_from_b64(b64)
+        assert restored == public_key_bytes
+
+    def test_b64_is_url_safe_no_padding(self):
+        _, public_key_bytes = generate_keypair()
+        b64 = public_key_to_b64(public_key_bytes)
+        assert isinstance(b64, str)
+        assert "+" not in b64
+        assert "/" not in b64
+        assert "=" not in b64
+
+    def test_b64_is_consistent_length(self):
+        # 65 bytes -> 87 base64 chars (without padding)
+        _, public_key_bytes = generate_keypair()
+        b64 = public_key_to_b64(public_key_bytes)
+        assert len(b64) == 87
+
+
+class TestKeyDerivation:
+    def test_both_sides_derive_same_key(self):
+        priv_a, pub_a = generate_keypair()
+        priv_b, pub_b = generate_keypair()
+
+        key_a = derive_shared_key(priv_a, pub_b)
+        key_b = derive_shared_key(priv_b, pub_a)
+
+        assert key_a == key_b
+
+    def test_derived_key_is_32_bytes(self):
+        priv_a, _ = generate_keypair()
+        _, pub_b = generate_keypair()
+
+        key = derive_shared_key(priv_a, pub_b)
+        assert len(key) == 32
+
+    def test_different_peers_produce_different_keys(self):
+        priv_a, _ = generate_keypair()
+        _, pub_b = generate_keypair()
+        _, pub_c = generate_keypair()
+
+        key_ab = derive_shared_key(priv_a, pub_b)
+        key_ac = derive_shared_key(priv_a, pub_c)
+        assert key_ab != key_ac
+
+    def test_key_derivation_with_b64_roundtrip(self):
+        """Public key survives base64 serialization for key exchange."""
+        priv_a, pub_a = generate_keypair()
+        priv_b, pub_b = generate_keypair()
+
+        # Simulate sending public keys as base64 strings
+        pub_a_restored = public_key_from_b64(public_key_to_b64(pub_a))
+        pub_b_restored = public_key_from_b64(public_key_to_b64(pub_b))
+
+        key_a = derive_shared_key(priv_a, pub_b_restored)
+        key_b = derive_shared_key(priv_b, pub_a_restored)
+
+        assert key_a == key_b
+
+
+class TestEncryptDecrypt:
+    def test_roundtrip(self):
+        priv_a, pub_a = generate_keypair()
+        priv_b, pub_b = generate_keypair()
+        key = derive_shared_key(priv_a, pub_b)
+
+        plaintext = {"type": "job_status", "epoch": 42, "loss": 0.003}
+        nonce, ciphertext = encrypt(key, plaintext)
+        decrypted = decrypt(key, nonce, ciphertext)
+
+        assert decrypted == plaintext
+
+    def test_ciphertext_differs_from_plaintext(self):
+        priv, pub = generate_keypair()
+        _, peer_pub = generate_keypair()
+        key = derive_shared_key(priv, peer_pub)
+
+        plaintext = {"secret": "data"}
+        _, ciphertext = encrypt(key, plaintext)
+
+        assert b"secret" not in ciphertext
+        assert b"data" not in ciphertext
+
+    def test_nonce_is_12_bytes(self):
+        key = derive_shared_key(*_make_key_pair())
+        nonce, _ = encrypt(key, {"test": True})
+        assert len(nonce) == 12
+
+    def test_each_encryption_produces_unique_nonce(self):
+        key = derive_shared_key(*_make_key_pair())
+        nonce1, _ = encrypt(key, {"test": True})
+        nonce2, _ = encrypt(key, {"test": True})
+        assert nonce1 != nonce2
+
+    def test_decrypt_with_wrong_key_fails(self):
+        key1 = derive_shared_key(*_make_key_pair())
+        key2 = derive_shared_key(*_make_key_pair())
+
+        nonce, ciphertext = encrypt(key1, {"secret": True})
+
+        with pytest.raises(InvalidTag):
+            decrypt(key2, nonce, ciphertext)
+
+    def test_decrypt_with_tampered_ciphertext_fails(self):
+        key = derive_shared_key(*_make_key_pair())
+        nonce, ciphertext = encrypt(key, {"data": "value"})
+
+        tampered = bytearray(ciphertext)
+        tampered[0] ^= 0xFF
+        tampered = bytes(tampered)
+
+        with pytest.raises(InvalidTag):
+            decrypt(key, nonce, tampered)
+
+    def test_decrypt_with_wrong_nonce_fails(self):
+        key = derive_shared_key(*_make_key_pair())
+        nonce, ciphertext = encrypt(key, {"data": "value"})
+
+        wrong_nonce = bytes(b ^ 0xFF for b in nonce)
+
+        with pytest.raises(InvalidTag):
+            decrypt(key, nonce=wrong_nonce, ciphertext=ciphertext)
+
+    def test_bidirectional_encryption(self):
+        """Both sides can encrypt and the other can decrypt."""
+        priv_a, pub_a = generate_keypair()
+        priv_b, pub_b = generate_keypair()
+
+        key_a = derive_shared_key(priv_a, pub_b)
+        key_b = derive_shared_key(priv_b, pub_a)
+
+        # A encrypts, B decrypts
+        msg1 = {"from": "client", "type": "fs_list_req", "path": "/data"}
+        nonce1, ct1 = encrypt(key_a, msg1)
+        assert decrypt(key_b, nonce1, ct1) == msg1
+
+        # B encrypts, A decrypts
+        msg2 = {"from": "worker", "type": "fs_list_res", "entries": []}
+        nonce2, ct2 = encrypt(key_b, msg2)
+        assert decrypt(key_a, nonce2, ct2) == msg2
+
+    def test_overhead_is_16_bytes(self):
+        """AES-GCM adds exactly 16 bytes (auth tag) to ciphertext."""
+        key = derive_shared_key(*_make_key_pair())
+        plaintext = {"x": 1}
+        plaintext_bytes = json.dumps(plaintext, separators=(",", ":")).encode()
+        _, ciphertext = encrypt(key, plaintext)
+        assert len(ciphertext) == len(plaintext_bytes) + 16
+
+
+def _make_key_pair() -> tuple:
+    """Helper: generate keypair and return (private_key, peer_public_key_bytes)."""
+    priv, _ = generate_keypair()
+    _, peer_pub = generate_keypair()
+    return priv, peer_pub

--- a/tests/encryption/test_envelope.py
+++ b/tests/encryption/test_envelope.py
@@ -1,0 +1,150 @@
+"""Tests for encrypted relay message envelopes."""
+
+import pytest
+
+from sleap_rtc.encryption.ecdh import derive_shared_key, generate_keypair
+from sleap_rtc.encryption.envelope import ENCRYPTED_RELAY_TYPE, unwrap, wrap
+
+
+class TestWrap:
+    def test_envelope_has_correct_type(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "fs_list_req"})
+        assert envelope["type"] == ENCRYPTED_RELAY_TYPE
+
+    def test_envelope_has_session_id(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        assert envelope["session_id"] == session_id
+
+    def test_envelope_has_nonce_and_ciphertext(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        assert "nonce" in envelope
+        assert "ciphertext" in envelope
+        assert isinstance(envelope["nonce"], str)
+        assert isinstance(envelope["ciphertext"], str)
+
+    def test_envelope_includes_job_id_when_provided(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"}, job_id="job_abc123")
+        assert envelope["job_id"] == "job_abc123"
+
+    def test_envelope_includes_req_id_when_provided(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"}, req_id="req-uuid")
+        assert envelope["req_id"] == "req-uuid"
+
+    def test_envelope_excludes_job_id_when_not_provided(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        assert "job_id" not in envelope
+
+    def test_payload_not_readable_in_envelope(self):
+        key, session_id = _make_session()
+        message = {"type": "job_submit", "config": {"secret_path": "/mnt/data"}}
+        envelope = wrap(key, session_id, message)
+        envelope_str = str(envelope)
+        assert "secret_path" not in envelope_str
+        assert "/mnt/data" not in envelope_str
+
+
+class TestUnwrap:
+    def test_roundtrip(self):
+        key, session_id = _make_session()
+        message = {"type": "fs_list_req", "path": "/data", "offset": 0}
+        envelope = wrap(key, session_id, message)
+        result = unwrap(envelope, {session_id: key})
+        assert result == message
+
+    def test_unknown_session_id_returns_none(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        result = unwrap(envelope, {"other-session": key})
+        assert result is None
+
+    def test_wrong_key_returns_none(self):
+        key1, session_id = _make_session()
+        key2, _ = _make_session()
+        envelope = wrap(key1, session_id, {"type": "test"})
+        result = unwrap(envelope, {session_id: key2})
+        assert result is None
+
+    def test_missing_session_id_returns_none(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        del envelope["session_id"]
+        result = unwrap(envelope, {session_id: key})
+        assert result is None
+
+    def test_tampered_ciphertext_returns_none(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        # Tamper with the base64 ciphertext
+        ct = envelope["ciphertext"]
+        envelope["ciphertext"] = "A" + ct[1:]
+        result = unwrap(envelope, {session_id: key})
+        assert result is None
+
+    def test_malformed_envelope_returns_none(self):
+        result = unwrap(
+            {"type": ENCRYPTED_RELAY_TYPE, "session_id": "abc"},
+            {"abc": b"\x00" * 32},
+        )
+        assert result is None
+
+    def test_empty_key_lookup_returns_none(self):
+        key, session_id = _make_session()
+        envelope = wrap(key, session_id, {"type": "test"})
+        result = unwrap(envelope, {})
+        assert result is None
+
+
+class TestWrapUnwrapIntegration:
+    def test_bidirectional_with_separate_keys(self):
+        """Simulates client and worker each wrapping/unwrapping."""
+        priv_a, pub_a = generate_keypair()
+        priv_b, pub_b = generate_keypair()
+
+        key_a = derive_shared_key(priv_a, pub_b)
+        key_b = derive_shared_key(priv_b, pub_a)
+
+        session_id = "test-session-123"
+
+        # Client wraps, worker unwraps
+        msg1 = {"type": "fs_list_req", "path": "/data"}
+        envelope1 = wrap(key_a, session_id, msg1)
+        result1 = unwrap(envelope1, {session_id: key_b})
+        assert result1 == msg1
+
+        # Worker wraps, client unwraps
+        msg2 = {"type": "fs_list_res", "entries": [{"name": "file.slp"}]}
+        envelope2 = wrap(key_b, session_id, msg2, job_id="job_xyz")
+        result2 = unwrap(envelope2, {session_id: key_a})
+        assert result2 == msg2
+
+    def test_multiple_sessions_coexist(self):
+        """Worker handles multiple concurrent dashboard clients."""
+        key1, sid1 = _make_session()
+        key2, sid2 = _make_session()
+
+        key_lookup = {sid1: key1, sid2: key2}
+
+        env1 = wrap(key1, sid1, {"client": 1})
+        env2 = wrap(key2, sid2, {"client": 2})
+
+        assert unwrap(env1, key_lookup) == {"client": 1}
+        assert unwrap(env2, key_lookup) == {"client": 2}
+
+        # Cross-session doesn't work
+        assert unwrap(wrap(key1, sid2, {"bad": True}), key_lookup) is None
+
+
+def _make_session() -> tuple[bytes, str]:
+    """Helper: generate a session key and ID."""
+    import uuid
+
+    priv_a, _ = generate_keypair()
+    _, pub_b = generate_keypair()
+    key = derive_shared_key(priv_a, pub_b)
+    return key, str(uuid.uuid4())


### PR DESCRIPTION
## Summary

Adds end-to-end encryption for all relay messages between the dashboard and workers, so the signaling server **cannot read message payloads**. Previously, relay messages (file paths, job configs, training logs, control commands) were visible to the signaling server in plaintext. Now the server only sees opaque ciphertext with plaintext routing fields (`type`, `job_id`, `peer_id`).

**Crypto stack:** ECDH P-256 key exchange + HKDF-SHA256 + AES-256-GCM. Zero new dependencies — uses Python's `cryptography` library (already installed) and the browser's native Web Crypto API.

### How it works

1. User clicks "Next →" after selecting a worker in the Submit Job modal
2. Dashboard generates an ephemeral P-256 keypair + session UUID
3. Dashboard sends public key to worker via signaling server (`key_exchange`)
4. Worker generates its own keypair, derives shared AES-256 key via ECDH + HKDF
5. Worker sends its public key back (`key_exchange_response`)
6. Dashboard derives the same shared key
7. All subsequent relay messages are encrypted with AES-256-GCM

The signaling server routes messages by plaintext fields (`job_id`, `peer_id`) but cannot decrypt payloads. Ephemeral keys provide forward secrecy — each session uses fresh keys.

### What's encrypted

| Operation | Encrypted? |
|---|---|
| File browsing (fs_list, path validation, video checks) | Yes |
| Job submission (training config, inference params) | Yes |
| Job status, progress, epoch updates | Yes |
| Training logs | Yes |
| Cancel / Stop Early commands | Yes |
| Mesh signaling (ICE/SDP) | No — different code path, uses DTLS |
| Server notifications (peer_joined, heartbeat) | No — server-originated |

### Changes

**New: `sleap_rtc/encryption/`**
- `ecdh.py` — P-256 keypair generation, ECDH shared secret derivation, HKDF, AES-256-GCM encrypt/decrypt
- `envelope.py` — wrap/unwrap encrypted relay envelopes with plaintext routing metadata
- 35 unit tests covering key derivation, round-trip encryption, tamper detection, multi-session coexistence

**Modified: `sleap_rtc/worker/mesh_coordinator.py`**
- `_handle_key_exchange()` — generates keypair, derives AES key, stores session, responds
- `_decrypt_if_encrypted()` — decrypts incoming `encrypted_relay` messages before dispatch
- `_send_relay_response()` — encrypts outgoing responses when session is active
- `RelayChannel.send()` — encrypts job status/progress messages for encrypted sessions
- Session key storage with 24h pruning
- Both admin and non-admin handler loops support encryption
- **Bugfix:** `[stderr]`, `CR::`, and catch-all text handlers now gated to inference/track jobs only — training was flooding the relay with config dumps and tqdm progress bars

**Modified: `dashboard/app.js`**
- Web Crypto API: ECDH P-256 key generation, HKDF, AES-GCM encrypt/decrypt
- `_e2eInitKeyExchange()` — orchestrates key exchange with 5s timeout + retry
- `apiWorkerMessage()` — transparently encrypts when E2E is ready
- `apiFsList()` / `apiJobSubmit()` — rerouted through encrypted `apiWorkerMessage` when active
- `apiJobSubmit()` generates `job_id` client-side (since dedicated endpoint is bypassed)
- `sseConnect()` — decrypts `encrypted_relay` SSE events and re-dispatches by inner type
- `sjEnterStep3()` / `sjGoToInferenceStep()` — trigger key exchange on "Next →"

### Signaling server change (webRTC-connect)

Companion PR: one `elif` clause in `server.py` to forward `key_exchange_response` and `encrypted_relay` to the relay SSE channels. Branch: `amick/relay-server-encryption`.

### What's NOT covered (next steps)

- **sleap-app (Tauri):** needs the same Web Crypto key exchange in its TypeScript frontend. Worker-side code is already in place.
- **PyQt SLEAP GUI:** uses P2P data channels with DTLS — already encrypted, no changes needed.
- **Generic relay allowlisting:** `/api/worker/message` still forwards any message type. E2E encryption makes payloads unreadable but doesn't restrict message types.

### E2E test results

| Test | Result |
|---|---|
| Key exchange (browser + worker + signaling server logs) | Pass |
| Encrypted file browsing | Pass |
| Encrypted job submission (training + inference) | Pass |
| Encrypted status/progress/log streaming | Pass |
| Signaling server sees only `encrypted_relay` | Pass |
| Stop Early / Cancel through encrypted path | Pass |
| Training epoch metrics display | Pass |
| Inference log streaming | Pass |
| Page refresh → new key exchange | Pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)