### PR TITLE
Migrate dashboard to split /api/worker/{key,fs,job} endpoints

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -851,25 +851,46 @@ class SleapRTCDashboard {
     }
 
     /**
-     * Forward an arbitrary message to a worker via the signaling server.
-     * If E2E encryption is active, the message is encrypted before sending.
+     * Forward a message to a worker via the signaling server.
+     * Dispatches to the category-specific endpoint based on message type:
+     *   - key_exchange     → /api/worker/key  (plaintext bootstrap)
+     *   - job_assigned/cancel/stop → /api/worker/job (encrypted envelope)
+     *   - everything else  → /api/worker/fs  (encrypted envelope)
      */
     async apiWorkerMessage(roomId, peerId, message) {
-        let outMessage = message;
+        const msgType = message.type;
 
-        if (this._e2eReady && this._e2eSharedKey && message.type !== 'key_exchange') {
-            const { nonce, ciphertext } = await this._e2eEncrypt(message);
-            outMessage = {
-                type: 'encrypted_relay',
-                session_id: this._e2eSessionId,
-                nonce,
-                ciphertext,
-            };
+        // Plaintext key-exchange bootstrap — dedicated endpoint, nested shape
+        if (msgType === 'key_exchange') {
+            return this.apiRequest('/api/worker/key', {
+                method: 'POST',
+                body: JSON.stringify({ room_id: roomId, peer_id: peerId, message }),
+            });
         }
 
-        return this.apiRequest('/api/worker/message', {
+        // All other messages must be encrypted
+        if (!this._e2eReady || !this._e2eSharedKey) {
+            console.warn(`[relay] Dropping ${msgType} — E2E not ready`);
+            return;
+        }
+
+        const { nonce, ciphertext } = await this._e2eEncrypt(message);
+        const body = {
+            room_id: roomId,
+            peer_id: peerId,
+            session_id: this._e2eSessionId,
+            nonce,
+            ciphertext,
+        };
+
+        const isJob = msgType === 'job_assigned'
+            || msgType === 'job_cancel'
+            || msgType === 'job_stop';
+        const endpoint = isJob ? '/api/worker/job' : '/api/worker/fs';
+
+        return this.apiRequest(endpoint, {
             method: 'POST',
-            body: JSON.stringify({ room_id: roomId, peer_id: peerId, message: outMessage }),
+            body: JSON.stringify(body),
         });
     }
 


### PR DESCRIPTION
## Summary

Route relay-path messages from the generic `/api/worker/message` to the category-specific endpoints introduced in [webRTC-connect PR #31](https://github.com/talmolab/webRTC-connect/pull/31):

| Message type | New endpoint | Encryption |
|---|---|---|
| `key_exchange` | `/api/worker/key` | Plaintext bootstrap |
| `job_assigned`, `job_cancel`, `job_stop` | `/api/worker/job` | Encrypted envelope |
| `fs_list_req`, `use_worker_path`, `fs_check_videos` | `/api/worker/fs` | Encrypted envelope |

Encrypted requests now use the flat envelope `{room_id, peer_id, session_id, nonce, ciphertext}` — the signaling server stamps `type: "encrypted_relay"` on the outgoing WebSocket payload.

## What didn't change

- **All 7 callers of `apiWorkerMessage()`** — signature preserved, zero call-site edits
- **Encryption itself** — same ECDH P-256 + AES-256-GCM
- **Signaling server** — no changes, runs post-PR-#31 code already
- **Worker** — no changes, no rebuild
- **User-visible behavior** — none

## What stays on the server

`/api/worker/message` remains as a server-side backward-compat safety net (still allowlisted by PR #31). After this PR, no code in the sleap-rtc dashboard calls it. A later PR can migrate sleap-app and then remove the generic endpoint entirely.

## Test plan

- [x] Deployed dashboard from this branch against the production signaling server (post-`linux-amd64-latest` pull)
- [x] E2E key exchange succeeds; `[E2E] Key exchange complete` in console
- [x] File browsing works — both model checkpoints and SLP file selection
- [x] Server logs show `[KEY]`, `[FS]`, `[JOB]` tags per session, **zero `[MSG]`** lines from dashboard traffic
- [x] Browser Network panel: zero POSTs to `/api/worker/message`
- [ ] Job submission / cancel / stop-early (verify before merge)

## Rollback

Single-function revert restores the pre-PR working state. The legacy endpoint remains operational on the server.

## Follow-ups (not in this PR)

- Migrate sleap-app's `_sendWorkerMessage` (same pattern)
- Once both clients are off `/api/worker/message`, remove it from the signaling server