### PR TITLE
Multi-spec Inference for GUI

### DIFF
--- a/sleap_rtc/api.py
+++ b/sleap_rtc/api.py
@@ -49,6 +49,7 @@ __all__ = [
     # Remote execution
     "run_training",
     "run_inference",
+    "run_inference_batch",
     "ProgressEvent",
     "TrainingResult",
     "InferenceResult",
@@ -469,6 +470,22 @@ def _dispatch_inference_response(
         return True
 
     return False
+
+
+def _enriched_job_message_wrapper(
+    on_job_message: "Callable[[str, dict], None] | None",
+    job_index: int,
+    jobs_total: int,
+) -> "Callable[[str, dict], None]":
+    """Wrap on_job_message to inject job_index and jobs_total into payloads."""
+
+    def _wrapper(msg_type: str, data: dict):
+        data["job_index"] = job_index
+        data["jobs_total"] = jobs_total
+        if on_job_message is not None:
+            on_job_message(msg_type, data)
+
+    return _wrapper
 
 
 async def _run_single_spec_async(
@@ -2559,6 +2576,251 @@ def run_inference(
             on_job_message=on_job_message,
         )
     )
+
+
+def run_inference_batch(
+    specs: list["TrackJobSpec"],
+    room_id: str,
+    worker_id: str | None = None,
+    on_channel_ready: "Callable[[Callable[[str], None]], None] | None" = None,
+    on_job_message: "Callable[[str, dict], None] | None" = None,
+    on_log: "Callable[[str], None] | None" = None,
+    on_spec_complete: "Callable[[InferenceResult], None] | None" = None,
+    timeout: float = 3600.0,
+) -> list[InferenceResult]:
+    """Run multiple inference specs sequentially over a single WebRTC connection.
+
+    Opens one WebRTC connection to the worker and submits each spec in order.
+    If a spec fails the batch stops early (fail-fast).
+
+    Args:
+        specs: List of TrackJobSpec instances to run sequentially.
+        room_id: The room ID containing the worker.
+        worker_id: Specific worker ID. If None, auto-selects best available.
+        on_channel_ready: Optional callback invoked once with a thread-safe
+            ``send_fn(str)`` after the data channel is authenticated.
+        on_job_message: Optional callback invoked with ``(msg_type, payload)``
+            for typed ``JOB_*`` dispatches. Payloads are enriched with
+            ``job_index`` and ``jobs_total`` fields.
+        on_log: Optional callback invoked with raw log lines from the worker.
+        on_spec_complete: Optional callback invoked after each spec completes
+            (success or failure) with the corresponding ``InferenceResult``.
+        timeout: Maximum time to wait for each individual spec in seconds.
+
+    Returns:
+        List of InferenceResult, one per spec that was attempted. On fail-fast
+        the list will be shorter than *specs*.
+
+    Raises:
+        AuthenticationError: If user is not logged in.
+        RoomNotFoundError: If room does not exist or has no workers.
+    """
+    import asyncio
+
+    return asyncio.run(
+        _run_inference_batch_async(
+            specs=specs,
+            room_id=room_id,
+            worker_id=worker_id,
+            on_channel_ready=on_channel_ready,
+            on_job_message=on_job_message,
+            on_log=on_log,
+            on_spec_complete=on_spec_complete,
+            timeout=timeout,
+        )
+    )
+
+
+async def _run_inference_batch_async(
+    specs: list["TrackJobSpec"],
+    room_id: str,
+    worker_id: str | None = None,
+    on_channel_ready: "Callable[[Callable[[str], None]], None] | None" = None,
+    on_job_message: "Callable[[str, dict], None] | None" = None,
+    on_log: "Callable[[str], None] | None" = None,
+    on_spec_complete: "Callable[[InferenceResult], None] | None" = None,
+    timeout: float = 3600.0,
+) -> list["InferenceResult"]:
+    """Async implementation of run_inference_batch."""
+    import asyncio
+    import json
+    import uuid
+
+    import websockets
+    from aiortc import RTCPeerConnection, RTCSessionDescription
+
+    from sleap_rtc.auth.credentials import get_valid_jwt
+    from sleap_rtc.config import get_config
+
+    jwt = get_valid_jwt()
+    if jwt is None:
+        raise AuthenticationError("Not logged in. Call login() first.")
+
+    config = get_config()
+    batch_id = str(uuid.uuid4())[:8]
+    peer_id = f"api-infer-{uuid.uuid4().hex[:8]}"
+
+    # Response handling
+    response_queue: asyncio.Queue = asyncio.Queue()
+    pc = None
+
+    try:
+        async with websockets.connect(config.signaling_websocket) as ws:
+            # Register with room
+            register_msg = {
+                "type": "register",
+                "peer_id": peer_id,
+                "room_id": room_id,
+                "role": "client",
+                "jwt": jwt,
+                "metadata": {
+                    "tags": ["sleap-rtc", "api-inference"],
+                    "properties": {"purpose": "remote-inference-batch"},
+                },
+            }
+            await ws.send(json.dumps(register_msg))
+
+            # Wait for registration
+            while True:
+                response = json.loads(await ws.recv())
+                if response.get("type") == "registered_auth":
+                    break
+                if response.get("type") == "error":
+                    raise RoomNotFoundError(
+                        f"Failed to join room: {response.get('message', 'Unknown error')}"
+                    )
+
+            # Discover workers if not specified
+            if worker_id is None:
+                discover_msg = {
+                    "type": "discover_peers",
+                    "from_peer_id": peer_id,
+                    "filters": {
+                        "role": "worker",
+                        "room_id": room_id,
+                        "tags": ["sleap-rtc"],
+                    },
+                }
+                await ws.send(json.dumps(discover_msg))
+
+                while True:
+                    response = json.loads(await ws.recv())
+                    if response.get("type") == "peer_list":
+                        peers = response.get("peers", [])
+                        if not peers:
+                            raise RoomNotFoundError("No workers available in room")
+                        worker_id = peers[0].get("peer_id")
+                        break
+
+            # Create WebRTC connection
+            pc = RTCPeerConnection()
+            data_channel = pc.createDataChannel("inference")
+
+            channel_open = asyncio.Event()
+
+            # State machine for incoming FILE_META/bytes/END_OF_FILE
+            # transfers (the post-track predictions.slp stream from the
+            # worker).
+            file_receiver = _StreamedFileReceiver()
+
+            @data_channel.on("open")
+            def on_open():
+                channel_open.set()
+
+            @data_channel.on("message")
+            async def on_message(message):
+                if isinstance(message, bytes) and message == b"KEEP_ALIVE":
+                    return
+
+                if isinstance(message, bytes):
+                    file_receiver.handle_bytes(message)
+                    return
+
+                if isinstance(message, str):
+                    if file_receiver.handle_string(message):
+                        return
+
+                    await response_queue.put(message)
+
+            # Send offer
+            offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            offer_msg = json.dumps(
+                {
+                    "type": pc.localDescription.type,
+                    "sender": peer_id,
+                    "target": worker_id,
+                    "sdp": pc.localDescription.sdp,
+                }
+            )
+            await ws.send(offer_msg)
+
+            # Wait for answer
+            while True:
+                response = json.loads(await ws.recv())
+                if response.get("type") == "answer":
+                    answer = RTCSessionDescription(
+                        sdp=response.get("sdp"),
+                        type="answer",
+                    )
+                    await pc.setRemoteDescription(answer)
+                    break
+                elif response.get("type") == "candidate":
+                    candidate = response.get("candidate")
+                    if candidate:
+                        await pc.addIceCandidate(candidate)
+
+            # Wait for channel
+            await asyncio.wait_for(channel_open.wait(), timeout=30.0)
+
+            # Authenticate with worker via PSK
+            await _authenticate_channel(data_channel, response_queue)
+
+            # Expose thread-safe send function for bidirectional communication.
+            if on_channel_ready:
+                loop = asyncio.get_running_loop()
+
+                def _thread_safe_send(msg: str) -> None:
+                    loop.call_soon_threadsafe(data_channel.send, msg)
+
+                on_channel_ready(_thread_safe_send)
+
+            # Run specs sequentially over the single connection
+            results: list[InferenceResult] = []
+            for i, spec in enumerate(specs):
+                job_id = f"{batch_id}-{i}"
+                enriched = _enriched_job_message_wrapper(
+                    on_job_message, i, len(specs)
+                )
+                try:
+                    result = await _run_single_spec_async(
+                        spec=spec,
+                        job_id=job_id,
+                        data_channel=data_channel,
+                        response_queue=response_queue,
+                        file_receiver=file_receiver,
+                        timeout=timeout,
+                        on_job_message=enriched,
+                        on_log=on_log,
+                    )
+                except (ConfigurationError, JobError) as e:
+                    result = InferenceResult(
+                        job_id=job_id,
+                        success=False,
+                        error_message=str(e),
+                    )
+                results.append(result)
+                if on_spec_complete is not None:
+                    on_spec_complete(result)
+                if not result.success:
+                    break
+
+            return results
+
+    finally:
+        if pc:
+            await pc.close()
 
 
 async def _run_inference_async(

--- a/sleap_rtc/api.py
+++ b/sleap_rtc/api.py
@@ -523,9 +523,7 @@ async def _run_single_spec_async(
 
     # Submit job
     spec_json = spec.to_json()
-    submit_msg = (
-        f"{MSG_JOB_SUBMIT}{MSG_SEPARATOR}{job_id}{MSG_SEPARATOR}{spec_json}"
-    )
+    submit_msg = f"{MSG_JOB_SUBMIT}{MSG_SEPARATOR}{job_id}{MSG_SEPARATOR}{spec_json}"
     data_channel.send(submit_msg)
 
     # Process responses
@@ -560,9 +558,7 @@ async def _run_single_spec_async(
                 error_data = json.loads(error_json)
                 errors = error_data.get("errors", [])
                 error_msgs = [e.get("message", "Unknown") for e in errors]
-                raise ConfigurationError(
-                    f"Job rejected: {'; '.join(error_msgs)}"
-                )
+                raise ConfigurationError(f"Job rejected: {'; '.join(error_msgs)}")
             except json.JSONDecodeError:
                 raise ConfigurationError(f"Job rejected: {error_json}")
 
@@ -575,9 +571,7 @@ async def _run_single_spec_async(
                 # (Tasks 6-7), replace the worker-side path with
                 # our local temp path. The worker path is
                 # preserved as worker_output_path for v2 dual-mode.
-                _apply_received_predictions(
-                    file_receiver, result_data, "output_path"
-                )
+                _apply_received_predictions(file_receiver, result_data, "output_path")
                 # Notify the GUI dispatcher BEFORE we build the
                 # InferenceResult so the progress dialog can finish
                 # its "complete" animation before this function
@@ -2792,9 +2786,7 @@ async def _run_inference_batch_async(
             results: list[InferenceResult] = []
             for i, spec in enumerate(specs):
                 job_id = f"{batch_id}-{i}"
-                enriched = _enriched_job_message_wrapper(
-                    on_job_message, i, len(specs)
-                )
+                enriched = _enriched_job_message_wrapper(on_job_message, i, len(specs))
                 try:
                     result = await _run_single_spec_async(
                         spec=spec,
@@ -2823,5 +2815,3 @@ async def _run_inference_batch_async(
     finally:
         if pc:
             await pc.close()
-
-

--- a/sleap_rtc/api.py
+++ b/sleap_rtc/api.py
@@ -471,6 +471,142 @@ def _dispatch_inference_response(
     return False
 
 
+async def _run_single_spec_async(
+    spec: "TrackJobSpec",
+    job_id: str,
+    data_channel,
+    response_queue: "asyncio.Queue",
+    file_receiver: "_StreamedFileReceiver",
+    timeout: float,
+    on_job_message: "Callable[[str, dict], None] | None" = None,
+    on_log: "Callable[[str], None] | None" = None,
+) -> "InferenceResult":
+    """Submit a single TrackJobSpec and process responses until completion.
+
+    This is the job-specific portion extracted from ``_run_inference_async``.
+    It sends the spec over *data_channel*, reads responses from
+    *response_queue*, and returns an ``InferenceResult`` (success **or**
+    failure).  Callers decide whether to raise on failure.
+
+    Raises:
+        JobError: If the overall timeout is exceeded.
+        ConfigurationError: If the worker rejects the job.
+    """
+    import asyncio
+    import json
+
+    from sleap_rtc.protocol import (
+        MSG_JOB_SUBMIT,
+        MSG_JOB_ACCEPTED,
+        MSG_JOB_REJECTED,
+        MSG_JOB_COMPLETE,
+        MSG_JOB_FAILED,
+        MSG_SEPARATOR,
+    )
+
+    # Submit job
+    spec_json = spec.to_json()
+    submit_msg = (
+        f"{MSG_JOB_SUBMIT}{MSG_SEPARATOR}{job_id}{MSG_SEPARATOR}{spec_json}"
+    )
+    data_channel.send(submit_msg)
+
+    # Process responses
+    start_time = asyncio.get_event_loop().time()
+    server_job_id = None
+
+    while True:
+        elapsed = asyncio.get_event_loop().time() - start_time
+        remaining = timeout - elapsed
+        if remaining <= 0:
+            raise JobError("Inference timed out", job_id=job_id)
+
+        try:
+            response = await asyncio.wait_for(
+                response_queue.get(),
+                timeout=min(remaining, 60.0),
+            )
+        except asyncio.TimeoutError:
+            continue
+
+        if _dispatch_inference_response(response, on_job_message, on_log):
+            continue
+
+        if response.startswith(MSG_JOB_ACCEPTED):
+            parts = response.split(MSG_SEPARATOR)
+            server_job_id = parts[1] if len(parts) > 1 else job_id
+
+        elif response.startswith(MSG_JOB_REJECTED):
+            parts = response.split(MSG_SEPARATOR, 2)
+            error_json = parts[2] if len(parts) > 2 else "{}"
+            try:
+                error_data = json.loads(error_json)
+                errors = error_data.get("errors", [])
+                error_msgs = [e.get("message", "Unknown") for e in errors]
+                raise ConfigurationError(
+                    f"Job rejected: {'; '.join(error_msgs)}"
+                )
+            except json.JSONDecodeError:
+                raise ConfigurationError(f"Job rejected: {error_json}")
+
+        elif response.startswith(MSG_JOB_COMPLETE):
+            parts = response.split(MSG_SEPARATOR, 1)
+            result_json = parts[1] if len(parts) > 1 else "{}"
+            try:
+                result_data = json.loads(result_json)
+                # If the worker streamed predictions.slp to us
+                # (Tasks 6-7), replace the worker-side path with
+                # our local temp path. The worker path is
+                # preserved as worker_output_path for v2 dual-mode.
+                _apply_received_predictions(
+                    file_receiver, result_data, "output_path"
+                )
+                # Notify the GUI dispatcher BEFORE we build the
+                # InferenceResult so the progress dialog can finish
+                # its "complete" animation before this function
+                # returns. (Task 9)
+                if on_job_message is not None:
+                    on_job_message("JOB_COMPLETE", result_data)
+                return InferenceResult(
+                    job_id=server_job_id or job_id,
+                    success=True,
+                    duration_seconds=result_data.get("duration_seconds"),
+                    predictions_path=result_data.get("output_path"),
+                )
+            except json.JSONDecodeError:
+                if on_job_message is not None:
+                    on_job_message("JOB_COMPLETE", {})
+                return InferenceResult(
+                    job_id=server_job_id or job_id,
+                    success=True,
+                )
+
+        elif response.startswith(MSG_JOB_FAILED):
+            parts = response.split(MSG_SEPARATOR, 2)
+            error_json = parts[2] if len(parts) > 2 else "{}"
+            try:
+                error_data = json.loads(error_json)
+                error_msg = error_data.get("message", "Job failed")
+                duration = error_data.get("duration_seconds")
+            except json.JSONDecodeError:
+                error_data = {}
+                error_msg = "Job failed"
+                duration = None
+
+            if on_job_message is not None:
+                on_job_message(
+                    "JOB_FAILED",
+                    error_data if error_data else {"message": error_msg},
+                )
+
+            return InferenceResult(
+                job_id=server_job_id or job_id,
+                success=False,
+                duration_seconds=duration,
+                error_message=error_msg,
+            )
+
+
 # =============================================================================
 # Data Classes
 # =============================================================================
@@ -2452,16 +2588,6 @@ async def _run_inference_async(
     from aiortc import RTCPeerConnection, RTCSessionDescription
     from sleap_rtc.auth.credentials import get_valid_jwt
     from sleap_rtc.config import get_config
-    from sleap_rtc.protocol import (
-        MSG_JOB_SUBMIT,
-        MSG_JOB_ACCEPTED,
-        MSG_JOB_REJECTED,
-        MSG_JOB_PROGRESS,
-        MSG_JOB_LOG,
-        MSG_JOB_COMPLETE,
-        MSG_JOB_FAILED,
-        MSG_SEPARATOR,
-    )
     from sleap_rtc.jobs.spec import TrackJobSpec
 
     jwt = get_valid_jwt()
@@ -2491,7 +2617,6 @@ async def _run_inference_async(
     import asyncio
 
     response_queue: asyncio.Queue = asyncio.Queue()
-    result: InferenceResult | None = None
     pc = None
 
     try:
@@ -2629,116 +2754,20 @@ async def _run_inference_async(
 
                 on_channel_ready(_thread_safe_send)
 
-            # Submit job
-            spec_json = spec.to_json()
-            submit_msg = (
-                f"{MSG_JOB_SUBMIT}{MSG_SEPARATOR}{job_id}{MSG_SEPARATOR}{spec_json}"
+            result = await _run_single_spec_async(
+                spec=spec,
+                job_id=job_id,
+                data_channel=data_channel,
+                response_queue=response_queue,
+                file_receiver=file_receiver,
+                timeout=timeout,
+                on_job_message=on_job_message,
+                on_log=on_log,
             )
-            data_channel.send(submit_msg)
-
-            # Process responses
-            start_time = asyncio.get_event_loop().time()
-            server_job_id = None
-
-            while True:
-                elapsed = asyncio.get_event_loop().time() - start_time
-                remaining = timeout - elapsed
-                if remaining <= 0:
-                    raise JobError("Inference timed out", job_id=job_id)
-
-                try:
-                    response = await asyncio.wait_for(
-                        response_queue.get(),
-                        timeout=min(remaining, 60.0),
-                    )
-                except asyncio.TimeoutError:
-                    continue
-
-                if _dispatch_inference_response(response, on_job_message, on_log):
-                    continue
-
-                if response.startswith(MSG_JOB_ACCEPTED):
-                    parts = response.split(MSG_SEPARATOR)
-                    server_job_id = parts[1] if len(parts) > 1 else job_id
-
-                elif response.startswith(MSG_JOB_REJECTED):
-                    parts = response.split(MSG_SEPARATOR, 2)
-                    error_json = parts[2] if len(parts) > 2 else "{}"
-                    try:
-                        error_data = json.loads(error_json)
-                        errors = error_data.get("errors", [])
-                        error_msgs = [e.get("message", "Unknown") for e in errors]
-                        raise ConfigurationError(
-                            f"Job rejected: {'; '.join(error_msgs)}"
-                        )
-                    except json.JSONDecodeError:
-                        raise ConfigurationError(f"Job rejected: {error_json}")
-
-                elif response.startswith(MSG_JOB_COMPLETE):
-                    parts = response.split(MSG_SEPARATOR, 1)
-                    result_json = parts[1] if len(parts) > 1 else "{}"
-                    try:
-                        result_data = json.loads(result_json)
-                        # If the worker streamed predictions.slp to us
-                        # (Tasks 6–7), replace the worker-side path with
-                        # our local temp path. The worker path is
-                        # preserved as worker_output_path for v2 dual-mode.
-                        _apply_received_predictions(
-                            file_receiver, result_data, "output_path"
-                        )
-                        # Notify the GUI dispatcher BEFORE we build the
-                        # InferenceResult so the progress dialog can finish
-                        # its "complete" animation before this function
-                        # returns. (Task 9)
-                        if on_job_message is not None:
-                            on_job_message("JOB_COMPLETE", result_data)
-                        result = InferenceResult(
-                            job_id=server_job_id or job_id,
-                            success=True,
-                            duration_seconds=result_data.get("duration_seconds"),
-                            predictions_path=result_data.get("output_path"),
-                        )
-                    except json.JSONDecodeError:
-                        if on_job_message is not None:
-                            on_job_message("JOB_COMPLETE", {})
-                        result = InferenceResult(
-                            job_id=server_job_id or job_id,
-                            success=True,
-                        )
-                    break
-
-                elif response.startswith(MSG_JOB_FAILED):
-                    parts = response.split(MSG_SEPARATOR, 2)
-                    error_json = parts[2] if len(parts) > 2 else "{}"
-                    try:
-                        error_data = json.loads(error_json)
-                        error_msg = error_data.get("message", "Job failed")
-                        duration = error_data.get("duration_seconds")
-                    except json.JSONDecodeError:
-                        error_data = {}
-                        error_msg = "Job failed"
-                        duration = None
-
-                    if on_job_message is not None:
-                        on_job_message(
-                            "JOB_FAILED",
-                            error_data if error_data else {"message": error_msg},
-                        )
-
-                    result = InferenceResult(
-                        job_id=server_job_id or job_id,
-                        success=False,
-                        duration_seconds=duration,
-                        error_message=error_msg,
-                    )
-                    break
 
     finally:
         if pc:
             await pc.close()
-
-    if result is None:
-        raise JobError("Inference ended unexpectedly", job_id=job_id)
 
     if not result.success:
         raise JobError(

--- a/sleap_rtc/api.py
+++ b/sleap_rtc/api.py
@@ -500,7 +500,7 @@ async def _run_single_spec_async(
 ) -> "InferenceResult":
     """Submit a single TrackJobSpec and process responses until completion.
 
-    This is the job-specific portion extracted from ``_run_inference_async``.
+    This is the job-specific portion extracted from ``_run_inference_batch_async``.
     It sends the spec over *data_channel*, reads responses from
     *response_queue*, and returns an ``InferenceResult`` (success **or**
     failure).  Callers decide whether to raise on failure.
@@ -2552,30 +2552,32 @@ def run_inference(
         ConfigurationError: If job spec is invalid.
         JobError: If the inference job fails.
     """
-    import asyncio
+    from sleap_rtc.jobs.spec import TrackJobSpec
 
-    return asyncio.run(
-        _run_inference_async(
-            data_path=data_path,
-            model_paths=model_paths,
-            room_id=room_id,
-            worker_id=worker_id,
-            output_path=output_path,
-            batch_size=batch_size,
-            peak_threshold=peak_threshold,
-            only_suggested_frames=only_suggested_frames,
-            frames=frames,
-            frame_filter=frame_filter,
-            video_index=video_index,
-            exclude_user_labeled=exclude_user_labeled,
-            path_mappings=path_mappings,
-            progress_callback=progress_callback,
-            timeout=timeout,
-            on_channel_ready=on_channel_ready,
-            on_log=on_log,
-            on_job_message=on_job_message,
-        )
+    spec = TrackJobSpec(
+        data_path=data_path,
+        model_paths=model_paths,
+        output_path=output_path,
+        batch_size=batch_size,
+        peak_threshold=peak_threshold,
+        only_suggested_frames=only_suggested_frames,
+        exclude_user_labeled=exclude_user_labeled,
+        frames=frames,
+        frame_filter=frame_filter,
+        video_index=video_index,
+        path_mappings=path_mappings or {},
     )
+
+    results = run_inference_batch(
+        specs=[spec],
+        room_id=room_id,
+        worker_id=worker_id,
+        on_channel_ready=on_channel_ready,
+        on_job_message=on_job_message,
+        on_log=on_log,
+        timeout=timeout,
+    )
+    return results[0]
 
 
 def run_inference_batch(
@@ -2823,218 +2825,3 @@ async def _run_inference_batch_async(
             await pc.close()
 
 
-async def _run_inference_async(
-    data_path: str,
-    model_paths: list[str],
-    room_id: str,
-    worker_id: str | None,
-    output_path: str | None,
-    batch_size: int | None,
-    peak_threshold: float | None,
-    only_suggested_frames: bool,
-    frames: str | None,
-    frame_filter: str | None = None,
-    video_index: int | None = None,
-    exclude_user_labeled: bool = False,
-    path_mappings: dict[str, str] | None = None,
-    progress_callback: "Callable[[ProgressEvent], None] | None" = None,
-    timeout: float = 3600.0,
-    on_channel_ready: "Callable[[Callable[[str], None]], None] | None" = None,
-    on_log: "Callable[[str], None] | None" = None,
-    on_job_message: "Callable[[str, dict], None] | None" = None,
-) -> InferenceResult:
-    """Async implementation of run_inference."""
-    import json
-    import uuid
-    import websockets
-    from aiortc import RTCPeerConnection, RTCSessionDescription
-    from sleap_rtc.auth.credentials import get_valid_jwt
-    from sleap_rtc.config import get_config
-    from sleap_rtc.jobs.spec import TrackJobSpec
-
-    jwt = get_valid_jwt()
-    if jwt is None:
-        raise AuthenticationError("Not logged in. Call login() first.")
-
-    config = get_config()
-    peer_id = f"api-infer-{uuid.uuid4().hex[:8]}"
-    job_id = str(uuid.uuid4())[:8]
-
-    # Build job spec
-    spec = TrackJobSpec(
-        data_path=data_path,
-        model_paths=model_paths,
-        output_path=output_path,
-        batch_size=batch_size,
-        peak_threshold=peak_threshold,
-        only_suggested_frames=only_suggested_frames,
-        exclude_user_labeled=exclude_user_labeled,
-        frames=frames,
-        frame_filter=frame_filter,
-        video_index=video_index,
-        path_mappings=path_mappings or {},
-    )
-
-    # Response handling
-    import asyncio
-
-    response_queue: asyncio.Queue = asyncio.Queue()
-    pc = None
-
-    try:
-        async with websockets.connect(config.signaling_websocket) as ws:
-            # Register with room
-            register_msg = {
-                "type": "register",
-                "peer_id": peer_id,
-                "room_id": room_id,
-                "role": "client",
-                "jwt": jwt,
-                "metadata": {
-                    "tags": ["sleap-rtc", "api-inference"],
-                    "properties": {"purpose": "remote-inference"},
-                },
-            }
-            await ws.send(json.dumps(register_msg))
-
-            # Wait for registration
-            while True:
-                response = json.loads(await ws.recv())
-                if response.get("type") == "registered_auth":
-                    break
-                if response.get("type") == "error":
-                    raise RoomNotFoundError(
-                        f"Failed to join room: {response.get('message', 'Unknown error')}"
-                    )
-
-            # Discover workers if not specified
-            if worker_id is None:
-                discover_msg = {
-                    "type": "discover_peers",
-                    "from_peer_id": peer_id,
-                    "filters": {
-                        "role": "worker",
-                        "room_id": room_id,
-                        "tags": ["sleap-rtc"],
-                    },
-                }
-                await ws.send(json.dumps(discover_msg))
-
-                while True:
-                    response = json.loads(await ws.recv())
-                    if response.get("type") == "peer_list":
-                        peers = response.get("peers", [])
-                        if not peers:
-                            raise RoomNotFoundError("No workers available in room")
-                        worker_id = peers[0].get("peer_id")
-                        break
-
-            # Create WebRTC connection
-            pc = RTCPeerConnection()
-            data_channel = pc.createDataChannel("inference")
-
-            channel_open = asyncio.Event()
-
-            # State machine for incoming FILE_META/bytes/END_OF_FILE
-            # transfers (the post-track predictions.slp stream from the
-            # worker — mirrors the training-side wiring landed in PR #79).
-            file_receiver = _StreamedFileReceiver()
-
-            @data_channel.on("open")
-            def on_open():
-                channel_open.set()
-
-            @data_channel.on("message")
-            async def on_message(message):
-                # Filter out the worker's KEEP_ALIVE heartbeat (10-byte
-                # binary) BEFORE any other handling. If we let it fall
-                # through to file_receiver.handle_bytes(), an in-flight
-                # transfer would have those 10 bytes appended to its
-                # tempfile, corrupting the predictions.slp by 10 bytes.
-                if isinstance(message, bytes) and message == b"KEEP_ALIVE":
-                    return
-
-                if isinstance(message, bytes):
-                    # Binary message — treat as a file-transfer chunk.
-                    # If no FILE_META is active, the receiver silently
-                    # drops the bytes (backward-compatible).
-                    file_receiver.handle_bytes(message)
-                    return
-
-                if isinstance(message, str):
-                    # File-transfer control messages (FILE_META, END_OF_FILE)
-                    # are consumed by the receiver and not forwarded.
-                    if file_receiver.handle_string(message):
-                        return
-
-                    await response_queue.put(message)
-
-            # Send offer
-            offer = await pc.createOffer()
-            await pc.setLocalDescription(offer)
-
-            offer_msg = json.dumps(
-                {
-                    "type": pc.localDescription.type,
-                    "sender": peer_id,
-                    "target": worker_id,
-                    "sdp": pc.localDescription.sdp,
-                }
-            )
-            await ws.send(offer_msg)
-
-            # Wait for answer
-            while True:
-                response = json.loads(await ws.recv())
-                if response.get("type") == "answer":
-                    answer = RTCSessionDescription(
-                        sdp=response.get("sdp"),
-                        type="answer",
-                    )
-                    await pc.setRemoteDescription(answer)
-                    break
-                elif response.get("type") == "candidate":
-                    candidate = response.get("candidate")
-                    if candidate:
-                        await pc.addIceCandidate(candidate)
-
-            # Wait for channel
-            await asyncio.wait_for(channel_open.wait(), timeout=30.0)
-
-            # Authenticate with worker via PSK
-            await _authenticate_channel(data_channel, response_queue)
-
-            # Expose thread-safe send function for bidirectional communication.
-            # Mirrors the training-side wire surface in _run_training_async so the
-            # SLEAP GUI can hand the same `send_fn` to its InferenceProgressDialog
-            # Cancel button.
-            if on_channel_ready:
-                loop = asyncio.get_running_loop()
-
-                def _thread_safe_send(msg: str) -> None:
-                    loop.call_soon_threadsafe(data_channel.send, msg)
-
-                on_channel_ready(_thread_safe_send)
-
-            result = await _run_single_spec_async(
-                spec=spec,
-                job_id=job_id,
-                data_channel=data_channel,
-                response_queue=response_queue,
-                file_receiver=file_receiver,
-                timeout=timeout,
-                on_job_message=on_job_message,
-                on_log=on_log,
-            )
-
-    finally:
-        if pc:
-            await pc.close()
-
-    if not result.success:
-        raise JobError(
-            result.error_message or "Inference failed",
-            job_id=result.job_id,
-        )
-
-    return result

--- a/sleap_rtc/gui/runners.py
+++ b/sleap_rtc/gui/runners.py
@@ -542,7 +542,7 @@ class RemoteProgressBridge(QObject):
         """Thread-safe entry point for standalone-track JOB_* messages.
 
         This method is intended to be passed as the ``on_job_message``
-        callback to :func:`run_inference` (or :func:`_run_inference_async`).
+        callback to :func:`run_inference` (or :func:`run_inference_batch`).
         It is called from the WebRTC background thread and marshals the
         message to the main Qt thread via a queued signal, where
         :meth:`_dispatch_job_msg` creates and updates the

--- a/sleap_rtc/gui/runners.py
+++ b/sleap_rtc/gui/runners.py
@@ -588,6 +588,13 @@ class RemoteProgressBridge(QObject):
                 if self._inference_dialog._progress_bar.maximum() == 0:
                     self._inference_dialog._status_label.setText("Running inference…")
                     self._inference_dialog._progress_bar.setRange(0, 100)
+            # Multi-spec batch: show "video N of M" in the status label
+            jobs_total = data.get("jobs_total", 1)
+            job_index = data.get("job_index", 0)
+            if jobs_total > 1:
+                self._inference_dialog._status_label.setText(
+                    f"Running inference… (video {job_index + 1} of {jobs_total})"
+                )
             self._inference_dialog.append_log(clean)
             # Parse progress from rich progress bar lines, e.g.:
             #   "Predicting... 100% 35/35 ETA: 0:00:00 Elapsed: 0:00:01 47.8 FPS"
@@ -627,9 +634,20 @@ class RemoteProgressBridge(QObject):
             n_frames = data.get("n_frames") or self._last_n_frames
             n_with_instances = data.get("n_with_instances")
             n_empty = data.get("n_empty")
+            jobs_total = data.get("jobs_total", 1)
+            job_index = data.get("job_index", 0)
+            is_final = job_index >= jobs_total - 1
             logger.info(f"Track job complete — predictions at {predictions_path}")
             if self._inference_dialog is not None:
-                self._inference_dialog.finish(n_frames, n_with_instances, n_empty)
+                if is_final:
+                    self._inference_dialog.finish(n_frames, n_with_instances, n_empty)
+                else:
+                    # Mid-batch: reset for next spec
+                    self._inference_dialog._status_label.setText(
+                        f"Starting video {job_index + 2} of {jobs_total}…"
+                    )
+                    self._inference_dialog._progress_bar.setRange(0, 0)  # indeterminate
+                    self._inference_dialog._progress_bar.setValue(0)
             if self._on_predictions_ready and predictions_path:
                 try:
                     self._on_predictions_ready(predictions_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2335,3 +2335,57 @@ class TestRunSingleSpecAsync:
             "file_receiver", "timeout", "on_job_message", "on_log",
         }
         assert required.issubset(param_names)
+
+
+# =============================================================================
+# run_inference_batch signature tests
+# =============================================================================
+
+
+class TestRunInferenceBatchSignature:
+    """Verify run_inference_batch exists with the expected signature."""
+
+    def test_batch_is_importable(self):
+        from sleap_rtc.api import run_inference_batch
+        assert callable(run_inference_batch)
+
+    def test_batch_in_all_exports(self):
+        from sleap_rtc import api
+        assert "run_inference_batch" in api.__all__
+
+    def test_batch_accepts_specs_list(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "specs" in sig.parameters
+
+    def test_batch_accepts_on_spec_complete(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "on_spec_complete" in sig.parameters
+
+    def test_batch_accepts_on_job_message(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "on_job_message" in sig.parameters
+
+    def test_batch_accepts_on_log(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "on_log" in sig.parameters
+
+    def test_batch_accepts_room_id_and_worker_id(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "room_id" in sig.parameters
+        assert "worker_id" in sig.parameters
+
+    def test_batch_accepts_on_channel_ready(self):
+        import inspect
+        from sleap_rtc.api import run_inference_batch
+        sig = inspect.signature(run_inference_batch)
+        assert "on_channel_ready" in sig.parameters

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1826,15 +1826,15 @@ class TestMsgJobCompletePathRewrite:
 
     def test_run_inference_async_calls_apply_received_predictions_for_output_path(self):
         """Source-grep regression: the MSG_JOB_COMPLETE dispatch in
-        _run_inference_async must invoke _apply_received_predictions with
-        the 'output_path' field name.
+        _run_single_spec_async (called by _run_inference_async) must invoke
+        _apply_received_predictions with the 'output_path' field name.
         """
         import inspect
-        from sleap_rtc.api import _run_inference_async
+        from sleap_rtc.api import _run_single_spec_async
 
-        src = inspect.getsource(_run_inference_async)
+        src = inspect.getsource(_run_single_spec_async)
         assert "_apply_received_predictions(" in src, (
-            "Task 5 wiring missing: helper not invoked in _run_inference_async"
+            "Task 5 wiring missing: helper not invoked in _run_single_spec_async"
         )
         assert '"output_path"' in src, (
             "Task 5 wiring missing: 'output_path' field name not present"
@@ -2310,3 +2310,28 @@ class TestListWorkersNameResolution:
 
         assert len(workers) == 1
         assert workers[0].name == "worker-abc123"
+
+
+# =============================================================================
+# _run_single_spec_async helper extraction tests
+# =============================================================================
+
+
+class TestRunSingleSpecAsync:
+    """Verify the extracted _run_single_spec_async helper exists with expected signature."""
+
+    def test_helper_exists_and_is_callable(self):
+        from sleap_rtc.api import _run_single_spec_async
+        import inspect
+        assert inspect.iscoroutinefunction(_run_single_spec_async)
+
+    def test_helper_accepts_required_params(self):
+        import inspect
+        from sleap_rtc.api import _run_single_spec_async
+        sig = inspect.signature(_run_single_spec_async)
+        param_names = set(sig.parameters.keys())
+        required = {
+            "spec", "job_id", "data_channel", "response_queue",
+            "file_receiver", "timeout", "on_job_message", "on_log",
+        }
+        assert required.issubset(param_names)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1073,7 +1073,7 @@ class TestRunInference:
             predictions_path="/data/predictions.slp",
         )
 
-        with patch("asyncio.run", return_value=mock_result):
+        with patch("sleap_rtc.api.run_inference_batch", return_value=[mock_result]):
             result = run_inference("/data.slp", ["/model1"], "room-1")
             assert result.success is True
             assert result.predictions_path == "/data/predictions.slp"
@@ -1090,7 +1090,7 @@ class TestRunInference:
 #   END_OF_FILE
 #   MSG_JOB_COMPLETE::{"output_path": "<worker-side path>", ...}
 #
-# the on_message handler inside _run_inference_async must:
+# the on_message handler inside _run_inference_batch_async must:
 #   1. Drop b"KEEP_ALIVE" heartbeat bytes BEFORE any other routing
 #      (otherwise they'd be appended to the in-flight tempfile and
 #      corrupt predictions.slp).
@@ -1105,7 +1105,7 @@ class TestRunInference:
 
 
 class _CapturedOnMessage(Exception):
-    """Sentinel raised by the mock RTCPeerConnection after _run_inference_async
+    """Sentinel raised by the mock RTCPeerConnection after _run_inference_batch_async
     has registered its on_message handler, to abort the rest of the function.
 
     The captured handler is attached to this exception via the .handler attr
@@ -1114,7 +1114,7 @@ class _CapturedOnMessage(Exception):
 
 
 def _make_inference_async_mocks():
-    """Build the mock infrastructure needed to drive _run_inference_async far
+    """Build the mock infrastructure needed to drive _run_inference_batch_async far
     enough to register on_message, then abort.
 
     Returns a tuple of (patches_to_apply, fake_data_channel) where
@@ -1148,7 +1148,7 @@ def _make_inference_async_mocks():
 
         async def createOffer(self):
             # on_message has been registered by this point — abort the
-            # rest of _run_inference_async by raising the sentinel.
+            # rest of _run_inference_batch_async by raising the sentinel.
             raise _CapturedOnMessage()
 
         async def setLocalDescription(self, _desc):
@@ -1166,7 +1166,7 @@ def _make_inference_async_mocks():
     class _FakeWS:
         """Minimal async websocket that yields a 'registered_auth' on first
         recv and would yield a peer_list on the next, satisfying the
-        register + discover_peers loops in _run_inference_async.
+        register + discover_peers loops in _run_inference_batch_async.
         """
 
         def __init__(self):
@@ -1204,7 +1204,7 @@ def _make_inference_async_mocks():
 
 
 def _capture_on_message(monkeypatch_jwt: str = "fake-jwt"):
-    """Run _run_inference_async far enough to register on_message, capture
+    """Run _run_inference_batch_async far enough to register on_message, capture
     it, and return (on_message, file_receiver, response_queue).
 
     The on_message closure is the actual production closure, with the
@@ -1216,20 +1216,19 @@ def _capture_on_message(monkeypatch_jwt: str = "fake-jwt"):
     fake_data_channel, FakePC, FakeWSConnect = _make_inference_async_mocks()
 
     from sleap_rtc import api as api_mod
+    from sleap_rtc.jobs.spec import TrackJobSpec
+
+    spec = TrackJobSpec(
+        data_path="/data.slp",
+        model_paths=["/model1"],
+    )
 
     async def _drive():
         try:
-            await api_mod._run_inference_async(
-                data_path="/data.slp",
-                model_paths=["/model1"],
+            await api_mod._run_inference_batch_async(
+                specs=[spec],
                 room_id="room-1",
                 worker_id=None,
-                output_path=None,
-                batch_size=None,
-                peak_threshold=None,
-                only_suggested_frames=False,
-                frames=None,
-                progress_callback=None,
                 timeout=10.0,
             )
         except _CapturedOnMessage:
@@ -1249,7 +1248,7 @@ def _capture_on_message(monkeypatch_jwt: str = "fake-jwt"):
     on_message = fake_data_channel._handlers.get("message")
     assert on_message is not None, (
         "on_message was not registered — the mock chain aborted too early "
-        "or _run_inference_async was refactored without updating the test"
+        "or _run_inference_batch_async was refactored without updating the test"
     )
 
     # Extract file_receiver and response_queue from the closure cells.
@@ -1270,10 +1269,10 @@ def _capture_on_message(monkeypatch_jwt: str = "fake-jwt"):
 
 
 class TestRunInferenceAsyncMessageHandling:
-    """Tests that _run_inference_async's on_message handler routes messages
+    """Tests that _run_inference_batch_async's on_message handler routes messages
     to _StreamedFileReceiver and response_queue per the Task 4 wiring spec.
 
-    These tests drive _run_inference_async with mocked websockets/aiortc
+    These tests drive _run_inference_batch_async with mocked websockets/aiortc
     far enough to register the on_message closure, then invoke that
     closure directly with synthesized messages. This mirrors the
     training-side wiring landed in PR #79.
@@ -1757,7 +1756,7 @@ class TestInferenceCompletePathRewrite:
 
 
 class TestMsgJobCompletePathRewrite:
-    """Tests that the MSG_JOB_COMPLETE dispatch in _run_inference_async
+    """Tests that the MSG_JOB_COMPLETE dispatch in _run_single_spec_async
     substitutes the locally-received tempfile path for result_data['output_path']
     when a stream was received.
 
@@ -1826,8 +1825,8 @@ class TestMsgJobCompletePathRewrite:
 
     def test_run_inference_async_calls_apply_received_predictions_for_output_path(self):
         """Source-grep regression: the MSG_JOB_COMPLETE dispatch in
-        _run_single_spec_async (called by _run_inference_async) must invoke
-        _apply_received_predictions with the 'output_path' field name.
+        _run_single_spec_async must invoke _apply_received_predictions
+        with the 'output_path' field name.
         """
         import inspect
         from sleap_rtc.api import _run_single_spec_async
@@ -2114,34 +2113,34 @@ class TestTempPredictionAtexitCleanup:
 
 
 class TestRunInferenceAsyncSignature:
-    """Task 8: ``_run_inference_async`` and the public ``run_inference``
+    """Task 8: ``_run_inference_batch_async`` and the public ``run_inference``
     wrapper must accept ``on_channel_ready`` (thread-safe send hook),
     ``on_log`` (raw log line callback), and ``on_job_message`` (typed
     JOB_* dispatch callback) so a GUI can wire its Cancel button and
     progress dialog to the standalone-track flow.
     """
 
-    def test_run_inference_async_has_on_channel_ready(self):
+    def test_run_inference_batch_async_has_on_channel_ready(self):
         import inspect
-        from sleap_rtc.api import _run_inference_async
+        from sleap_rtc.api import _run_inference_batch_async
 
-        sig = inspect.signature(_run_inference_async)
+        sig = inspect.signature(_run_inference_batch_async)
         assert "on_channel_ready" in sig.parameters
         assert sig.parameters["on_channel_ready"].default is None
 
-    def test_run_inference_async_has_on_log(self):
+    def test_run_inference_batch_async_has_on_log(self):
         import inspect
-        from sleap_rtc.api import _run_inference_async
+        from sleap_rtc.api import _run_inference_batch_async
 
-        sig = inspect.signature(_run_inference_async)
+        sig = inspect.signature(_run_inference_batch_async)
         assert "on_log" in sig.parameters
         assert sig.parameters["on_log"].default is None
 
-    def test_run_inference_async_has_on_job_message(self):
+    def test_run_inference_batch_async_has_on_job_message(self):
         import inspect
-        from sleap_rtc.api import _run_inference_async
+        from sleap_rtc.api import _run_inference_batch_async
 
-        sig = inspect.signature(_run_inference_async)
+        sig = inspect.signature(_run_inference_batch_async)
         assert "on_job_message" in sig.parameters
         assert sig.parameters["on_job_message"].default is None
 
@@ -2153,22 +2152,6 @@ class TestRunInferenceAsyncSignature:
         for name in ("on_channel_ready", "on_log", "on_job_message"):
             assert name in sig.parameters, f"run_inference missing {name}"
             assert sig.parameters[name].default is None
-
-    def test_run_inference_async_has_frame_filter(self):
-        import inspect
-        from sleap_rtc.api import _run_inference_async
-
-        sig = inspect.signature(_run_inference_async)
-        assert "frame_filter" in sig.parameters
-        assert sig.parameters["frame_filter"].default is None
-
-    def test_run_inference_async_has_video_index(self):
-        import inspect
-        from sleap_rtc.api import _run_inference_async
-
-        sig = inspect.signature(_run_inference_async)
-        assert "video_index" in sig.parameters
-        assert sig.parameters["video_index"].default is None
 
     def test_run_inference_wrapper_has_frame_filter_and_video_index(self):
         import inspect
@@ -2188,7 +2171,7 @@ class TestProtocolConstants:
 
 
 class TestRunInferenceAsyncJobMessageForwarding:
-    """Task 9: ``_run_inference_async`` forwards each ``MSG_JOB_*`` wire
+    """Task 9: ``_run_single_spec_async`` forwards each ``MSG_JOB_*`` wire
     message to ``on_job_message`` with the typed name and parsed dict.
     """
 
@@ -2471,3 +2454,31 @@ class TestEnrichedJobMessageWrapper:
         assert captured[0][0] == "JOB_FAILED"
         assert captured[0][1]["job_index"] == 1
         assert captured[0][1]["message"] == "out of memory"
+
+
+class TestRunInferenceDelegatesToBatch:
+    """Verify run_inference delegates to run_inference_batch."""
+
+    def test_run_inference_signature_unchanged(self):
+        """run_inference still accepts all its original parameters."""
+        import inspect
+        from sleap_rtc.api import run_inference
+        sig = inspect.signature(run_inference)
+        expected = {
+            "data_path", "model_paths", "room_id", "worker_id",
+            "output_path", "batch_size", "peak_threshold",
+            "only_suggested_frames", "frames", "frame_filter",
+            "video_index", "exclude_user_labeled", "path_mappings",
+            "progress_callback", "timeout",
+            "on_channel_ready", "on_log", "on_job_message",
+        }
+        assert expected.issubset(set(sig.parameters.keys()))
+
+    def test_run_inference_return_type_is_single_result(self):
+        """Return annotation should be InferenceResult, not a list."""
+        import inspect
+        from sleap_rtc.api import run_inference
+        sig = inspect.signature(run_inference)
+        annotation = str(sig.return_annotation)
+        assert "list" not in annotation.lower()
+        assert "List" not in annotation

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2389,3 +2389,85 @@ class TestRunInferenceBatchSignature:
         from sleap_rtc.api import run_inference_batch
         sig = inspect.signature(run_inference_batch)
         assert "on_channel_ready" in sig.parameters
+
+
+class TestEnrichedJobMessageWrapper:
+    """Verify _enriched_job_message_wrapper injects job_index/jobs_total."""
+
+    def test_job_log_enriched_with_index(self):
+        """Wrapper injects job_index and jobs_total before forwarding."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        captured = []
+        def on_msg(msg_type, data):
+            captured.append((msg_type, data.copy()))
+
+        wrapper = _enriched_job_message_wrapper(on_msg, job_index=1, jobs_total=3)
+        wrapper("JOB_LOG", {"text": "hello"})
+
+        assert len(captured) == 1
+        assert captured[0][0] == "JOB_LOG"
+        assert captured[0][1]["job_index"] == 1
+        assert captured[0][1]["jobs_total"] == 3
+        assert captured[0][1]["text"] == "hello"
+
+    def test_enrichment_with_none_callback_does_not_crash(self):
+        """When on_job_message is None, wrapper still enriches (no-op forward)."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        wrapper = _enriched_job_message_wrapper(None, job_index=0, jobs_total=1)
+        # Should not raise
+        data = {"text": "test"}
+        wrapper("JOB_LOG", data)
+        # Data should still be enriched (mutated in-place)
+        assert data["job_index"] == 0
+        assert data["jobs_total"] == 1
+
+    def test_enrichment_preserves_existing_payload_fields(self):
+        """Existing fields in the data dict are not lost."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        captured = []
+        wrapper = _enriched_job_message_wrapper(
+            lambda t, d: captured.append(d.copy()), job_index=2, jobs_total=5,
+        )
+        wrapper("JOB_PROGRESS", {"progress": 0.5, "batch": 10})
+        assert captured[0]["progress"] == 0.5
+        assert captured[0]["batch"] == 10
+        assert captured[0]["job_index"] == 2
+        assert captured[0]["jobs_total"] == 5
+
+    def test_different_indices_produce_different_wrappers(self):
+        """Each wrapper instance captures its own job_index."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        results = []
+        cb = lambda t, d: results.append(d.copy())
+        w0 = _enriched_job_message_wrapper(cb, job_index=0, jobs_total=3)
+        w1 = _enriched_job_message_wrapper(cb, job_index=1, jobs_total=3)
+        w2 = _enriched_job_message_wrapper(cb, job_index=2, jobs_total=3)
+        w0("JOB_LOG", {"x": 1})
+        w1("JOB_LOG", {"x": 2})
+        w2("JOB_LOG", {"x": 3})
+        assert [r["job_index"] for r in results] == [0, 1, 2]
+        assert all(r["jobs_total"] == 3 for r in results)
+
+    def test_enrichment_works_for_job_complete(self):
+        """JOB_COMPLETE payloads are also enriched."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        captured = []
+        wrapper = _enriched_job_message_wrapper(
+            lambda t, d: captured.append((t, d.copy())), job_index=0, jobs_total=1,
+        )
+        wrapper("JOB_COMPLETE", {"output_path": "/tmp/pred.slp"})
+        assert captured[0][0] == "JOB_COMPLETE"
+        assert captured[0][1]["job_index"] == 0
+        assert captured[0][1]["output_path"] == "/tmp/pred.slp"
+
+    def test_enrichment_works_for_job_failed(self):
+        """JOB_FAILED payloads are also enriched."""
+        from sleap_rtc.api import _enriched_job_message_wrapper
+        captured = []
+        wrapper = _enriched_job_message_wrapper(
+            lambda t, d: captured.append((t, d.copy())), job_index=1, jobs_total=2,
+        )
+        wrapper("JOB_FAILED", {"message": "out of memory"})
+        assert captured[0][0] == "JOB_FAILED"
+        assert captured[0][1]["job_index"] == 1
+        assert captured[0][1]["message"] == "out of memory"

--- a/tests/test_gui_runners.py
+++ b/tests/test_gui_runners.py
@@ -1353,3 +1353,125 @@ class TestHandleJobMessage:
         assert bridge._last_n_frames == 35
         assert bridge._inference_dialog is not None
         bridge._inference_dialog.close()
+
+
+class TestDispatchJobMsgMultiSpec:
+    """Verify _dispatch_job_msg reads job_index/jobs_total for multi-spec."""
+
+    def test_first_job_log_shows_video_1_of_3(self):
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "Starting...", "job_index": 0, "jobs_total": 3,
+            })
+            MockDialog.assert_called_once()
+            instance.show.assert_called_once()
+            # After creating dialog with multi-spec, status should show video count
+            instance._status_label.setText.assert_called_with(
+                "Running inference… (video 1 of 3)"
+            )
+
+    def test_second_spec_log_updates_to_video_2_of_3(self):
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            # First call: dialog just created, maximum returns default (not 0)
+            # After first JOB_LOG creates dialog, subsequent calls check maximum()
+            instance._progress_bar.maximum.return_value = 100
+            MockDialog.return_value = instance
+            # First spec
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "line1", "job_index": 0, "jobs_total": 3,
+            })
+            # Complete first spec (mid-batch)
+            bridge._dispatch_job_msg("JOB_COMPLETE", {
+                "output_path": "/tmp/pred0.slp", "job_index": 0, "jobs_total": 3,
+            })
+            # Second spec starts — after mid-batch complete, progress bar was
+            # reset to indeterminate (max=0)
+            instance._progress_bar.maximum.return_value = 0
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "line2", "job_index": 1, "jobs_total": 3,
+            })
+            # The last setText call should be the video 2 of 3 label
+            calls = instance._status_label.setText.call_args_list
+            last_label = calls[-1][0][0]
+            assert "2 of 3" in last_label
+
+    def test_single_spec_no_video_label(self):
+        """When jobs_total=1, don't show 'video 1 of 1' — same as current behavior."""
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "line1", "job_index": 0, "jobs_total": 1,
+            })
+            # Status label should NOT contain "of" — no multi-spec label
+            for call in instance._status_label.setText.call_args_list:
+                assert "of" not in call[0][0].lower()
+
+    def test_no_enrichment_fields_works_like_before(self):
+        """Without job_index/jobs_total (pre-batch callers), no crash."""
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            bridge._dispatch_job_msg("JOB_LOG", {"text": "hello"})
+            MockDialog.assert_called_once()
+            instance.show.assert_called_once()
+            instance.append_log.assert_called_once_with("hello")
+
+    def test_job_complete_mid_batch_resets_progress(self):
+        """JOB_COMPLETE for a non-final spec resets progress bar to indeterminate."""
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            # Open dialog
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "Predicting... 50% 5/10", "job_index": 0, "jobs_total": 3,
+            })
+            # Complete first spec (non-final)
+            bridge._dispatch_job_msg("JOB_COMPLETE", {
+                "output_path": "/tmp/pred.slp", "job_index": 0, "jobs_total": 3,
+            })
+            # Should NOT call finish() — mid-batch
+            instance.finish.assert_not_called()
+            # Should reset to indeterminate
+            instance._progress_bar.setRange.assert_called_with(0, 0)
+            instance._progress_bar.setValue.assert_called_with(0)
+
+    def test_job_complete_final_spec_calls_finish(self):
+        """JOB_COMPLETE for the final spec calls finish() as normal."""
+        bridge = RemoteProgressBridge()
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            # Open dialog
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "Predicting... 100% 10/10", "job_index": 2, "jobs_total": 3,
+            })
+            bridge._dispatch_job_msg("JOB_COMPLETE", {
+                "output_path": "/tmp/pred.slp", "job_index": 2, "jobs_total": 3,
+            })
+            # Final spec — should call finish()
+            instance.finish.assert_called_once()
+
+    def test_mid_batch_complete_still_fires_predictions_ready(self):
+        """on_predictions_ready fires for every spec, not just the final one."""
+        bridge = RemoteProgressBridge()
+        received: list[str] = []
+        bridge.set_predictions_ready_callback(received.append)
+        with patch("sleap_rtc.gui.widgets.InferenceProgressDialog") as MockDialog:
+            instance = MagicMock()
+            MockDialog.return_value = instance
+            bridge._dispatch_job_msg("JOB_LOG", {
+                "text": "line1", "job_index": 0, "jobs_total": 3,
+            })
+            bridge._dispatch_job_msg("JOB_COMPLETE", {
+                "output_path": "/tmp/pred0.slp", "job_index": 0, "jobs_total": 3,
+            })
+        assert received == ["/tmp/pred0.slp"]


### PR DESCRIPTION
## Summary

- **`run_inference_batch` API**: New public function that runs multiple `TrackJobSpec`s over a single WebRTC connection, eliminating per-video reconnection overhead. `run_inference` now delegates to `run_inference_batch([spec])` internally.
- **Payload enrichment**: `on_job_message` callbacks receive `job_index` / `jobs_total` fields so the GUI can show "video N of M" progress during multi-spec batches.
- **`on_spec_complete` callback**: Fires after each spec finishes, enabling incremental prediction merging (predictions appear video-by-video).
- **Multi-spec dialog transitions**: `RemoteProgressBridge._dispatch_job_msg` reads enriched payloads to update the dialog between specs — progress resets to indeterminate, status shows "Starting video N of M…".

### SLEAP fork changes (local, `amick/fix-model-queue`)

- **`_track_target_to_spec_fields` returns `List[dict]`**: All targets return a list (length 1 for most, length N for random-all-videos).
- **Random-all-videos sampling**: Per-video frame sampling with `video_infos` parameter — handles `exclude_user_labeled` filtering, clamping, and skipping empty videos.
- **Orchestrator batch flow**: `_run_remote_inference` builds `List[TrackJobSpec]`, calls `run_inference_batch` with `on_spec_complete` for incremental merge.

### What does NOT change

- Wire protocol (no new message types)
- Worker / `JobExecutor` (unchanged)
- `TrackJobSpec` fields (unchanged)
- `run_inference` public signature (backward compatible)

## Test plan

- [ ] Verify all existing single-spec targets (suggestions, all_videos, current video, clip, frame) still work unchanged
- [ ] Test "Random sample (all videos)" with a multi-video SLP project
- [ ] Verify cancel mid-batch stops remaining videos and keeps completed predictions
- [ ] Verify "video N of M" progress label appears during multi-video inference
- [ ] Verify predictions appear incrementally (after each video, not all at once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)