### PR TITLE
Add tracking/preprocessing fields to TrackJobSpec

### DIFF
--- a/sleap_rtc/jobs/builder.py
+++ b/sleap_rtc/jobs/builder.py
@@ -199,6 +199,34 @@ class CommandBuilder:
         if spec.frames:
             cmd.extend(["--frames", spec.frames])
 
+        # Tracking parameters
+        if spec.tracker or spec.similarity or spec.match or spec.track_window:
+            cmd.append("--tracking")
+        if spec.tracker == "flow":
+            cmd.append("--use_flow")
+        if spec.similarity:
+            if spec.similarity == "centroids":
+                cmd.extend(["--features", "centroids"])
+                cmd.extend(["--scoring_method", "euclidean_dist"])
+            else:
+                cmd.extend(["--scoring_method", spec.similarity])
+        if spec.match:
+            cmd.extend(["--track_matching_method", spec.match])
+        if spec.track_window is not None:
+            cmd.extend(["--tracking_window_size", str(spec.track_window)])
+        if spec.robust is not None:
+            cmd.extend(["--robust_best_instance", str(spec.robust)])
+        if spec.max_tracks is not None:
+            cmd.extend(["--max_tracks", str(spec.max_tracks)])
+        if spec.connect_single_breaks:
+            cmd.append("--post_connect_single_breaks")
+
+        # Preprocessing
+        if spec.ensure_channels == "rgb":
+            cmd.append("--ensure_rgb")
+        elif spec.ensure_channels == "grayscale":
+            cmd.append("--ensure_grayscale")
+
         return cmd
 
     def build_command(

--- a/sleap_rtc/jobs/spec.py
+++ b/sleap_rtc/jobs/spec.py
@@ -139,6 +139,16 @@ class TrackJobSpec:
     frame_filter: Optional[str] = None
     video_index: Optional[int] = None
     path_mappings: Dict[str, str] = field(default_factory=dict)
+    # Tracking parameters
+    tracker: Optional[str] = None  # "simple" or "flow"
+    similarity: Optional[str] = None  # "oks", "iou", "centroids", "euclidean_dist"
+    match: Optional[str] = None  # "hungarian" or "greedy"
+    track_window: Optional[int] = None
+    robust: Optional[float] = None
+    max_tracks: Optional[int] = None
+    connect_single_breaks: bool = False
+    # Preprocessing
+    ensure_channels: Optional[str] = None  # "rgb" or "grayscale"
 
     _VALID_FRAME_FILTERS: ClassVar[Set[Optional[str]]] = {
         None,
@@ -181,6 +191,8 @@ class TrackJobSpec:
         """Deserialize spec from JSON string."""
         parsed = json.loads(data)
         parsed.pop("type", None)
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        parsed = {k: v for k, v in parsed.items() if k in known_fields}
         return cls(**parsed)
 
     def to_dict(self) -> dict:
@@ -197,6 +209,8 @@ class TrackJobSpec:
         """Create spec from dictionary."""
         data = dict(data)  # Make a copy
         data.pop("type", None)
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        data = {k: v for k, v in data.items() if k in known_fields}
         return cls(**data)
 
 


### PR DESCRIPTION
## Summary

- **Add 8 new fields to `TrackJobSpec`**: `tracker`, `similarity`, `match`, `track_window`, `robust`, `max_tracks`, `connect_single_breaks`, `ensure_channels` — these are sent by sleap-app's inference panel but were previously crashing the worker on deserialization
- **Add `known_fields` filtering** to `from_json()` and `from_dict()` for forward compatibility (matching `TrainJobSpec`'s existing pattern) — unknown fields are silently dropped instead of crashing
- **Translate new fields to correct sleap-nn CLI flags** in `build_track_command()`: `tracker=flow` → `--use_flow`, `similarity` → `--scoring_method` (with centroids special case → `--features centroids --scoring_method euclidean_dist`), `match` → `--track_matching_method`, etc.

## Test plan

- [x] `TrackJobSpec.from_dict()` accepts new fields and ignores unknown fields
- [x] `TrackJobSpec.from_json()` accepts new fields and ignores unknown fields  
- [x] `build_track_command()` produces correct sleap-nn flags for simple tracker
- [x] `build_track_command()` produces `--use_flow` for flow tracker
- [x] `build_track_command()` produces `--features centroids --scoring_method euclidean_dist` for centroids similarity
- [x] `build_track_command()` produces `--ensure_rgb` / `--ensure_grayscale` for channel preprocessing
- [ ] E2E: run remote inference from sleap-app with tracking enabled — verify worker doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)